### PR TITLE
Fix GetEnviron issue on Windows MSVC.

### DIFF
--- a/sources/niLang/src/API/niLang/IOSProcess.h
+++ b/sources/niLang/src/API/niLang/IOSProcess.h
@@ -163,7 +163,8 @@ struct iOSProcessManager : public iUnknown {
 
   //! Get the current environment variables.
   //! {Property}
-  virtual Ptr<tStringCMap> __stdcall GetEnviron() const = 0;
+  //! \remark This is not named GetEnviron because MSVC has an variable called `environ`.
+  virtual Ptr<tStringCMap> __stdcall GetEnvs() const = 0;
 };
 
 #ifndef niNoProcess

--- a/sources/niLang/src/API/niLang/Platforms/Win32/Win32_Redef.h
+++ b/sources/niLang/src/API/niLang/Platforms/Win32/Win32_Redef.h
@@ -48,7 +48,6 @@
 #undef CreateProcess
 #undef CreateSemaphore
 #undef CreateThread
-#undef CreateThread
 #undef CreateWindow
 #undef CreateWindowEx
 #undef DispatchMessage
@@ -58,23 +57,21 @@
 #undef GetClassName
 #undef GetCommandLine
 #undef GetCurrentTime
-#undef GetCurrentTime
-#undef GetFileAttributes
 #undef GetFileAttributes
 #undef GetMessage
 #undef GetModuleFileName
 #undef GetObject
+#undef GetUserName
 #undef LoadBitmap
+#undef max
 #undef Message
 #undef MessageBox
+#undef min
 #undef PeekMessage
 #undef PostMessage
 #undef SendMessage
 #undef SetFileAttributes
 #undef SetPort
-#undef max
-#undef min
-#undef GetUserName
 
 #undef niWin32API
 #define niWin32API(FUNC)  ::FUNC##W

--- a/sources/niLang/src/OSProcess.cpp
+++ b/sources/niLang/src/OSProcess.cpp
@@ -574,7 +574,7 @@ class cOSProcessManager : public cIUnknownImpl<ni::iOSProcessManager,eIUnknownIm
 
     Ptr<tStringCMap> defaultEnvs;
     if (!apEnvs) {
-      defaultEnvs = this->GetEnviron();
+      defaultEnvs = this->GetEnvs();
       apEnvs = defaultEnvs.ptr();
     }
 
@@ -880,7 +880,7 @@ class cOSProcessManager : public cIUnknownImpl<ni::iOSProcessManager,eIUnknownIm
     return agetcwd();
   }
 
-  Ptr<tStringCMap> __stdcall GetEnviron() const {
+  Ptr<tStringCMap> __stdcall GetEnvs() const {
     Ptr<tStringCMap> e = tStringCMap::Create();
     for (char **current = _GetEnviron(); *current; current++) {
       cString c = *current;

--- a/sources/niLang/src/_idl/IOSProcess.h.idl.inl
+++ b/sources/niLang/src/_idl/IOSProcess.h.idl.inl
@@ -261,14 +261,14 @@ IDLC_METH_BEGIN(ni,iOSProcessManager,GetCwd,0)
 IDLC_METH_END(ni,iOSProcessManager,GetCwd,0)
 #endif // niMinFeatures(15)
 
-/** ni -> iOSProcessManager::GetEnviron/0 -> MIN FEATURES '15' **/
+/** ni -> iOSProcessManager::GetEnvs/0 -> MIN FEATURES '15' **/
 #if niMinFeatures(15)
-/** ni -> iOSProcessManager::GetEnviron/0 **/
-IDLC_METH_BEGIN(ni,iOSProcessManager,GetEnviron,0)
+/** ni -> iOSProcessManager::GetEnvs/0 **/
+IDLC_METH_BEGIN(ni,iOSProcessManager,GetEnvs,0)
 	IDLC_DECL_RETVAR(Ptr<tStringCMap>,_Ret)
-	IDLC_METH_CALL(_Ret,ni,iOSProcessManager,GetEnviron,0,())
+	IDLC_METH_CALL(_Ret,ni,iOSProcessManager,GetEnvs,0,())
 	IDLC_RET_FROM_INTF(,_Ret)
-IDLC_METH_END(ni,iOSProcessManager,GetEnviron,0)
+IDLC_METH_END(ni,iOSProcessManager,GetEnvs,0)
 #endif // niMinFeatures(15)
 
 IDLC_END_INTF(ni,iOSProcessManager)

--- a/sources/niLang/src/_idl/IOSProcess.h.idl.xml
+++ b/sources/niLang/src/_idl/IOSProcess.h.idl.xml
@@ -394,14 +394,16 @@
 			</method>
 			<method
 				const="yes"
-				java_name="getEnviron"
+				java_name="getEnvs"
 				min_features="15"
-				name="GetEnviron"
+				name="GetEnvs"
 				num_parameters="0"
 				property="get"
-				property_name2="environ"
-				property_name="environ">
-				<comments desc="Get the current environment variables. "/>
+				property_name2="envs"
+				property_name="envs">
+				<comments desc="Get the current environment variables. ">
+					<remark text="This is not named GetEnviron because MSVC has an variable called `environ`. "/>
+				</comments>
 				<return type="Ptr&lt;tStringCMap&gt;" typec="Ptr&lt;tStringCMap&gt;" typei="ni::eType_IUnknown|ni::eTypeFlags_Pointer"/>
 			</method>
 		</interface>

--- a/sources/niLang/src/_niLang_ModuleDef.cpp
+++ b/sources/niLang/src/_niLang_ModuleDef.cpp
@@ -20357,13 +20357,13 @@ static const ni::sMethodDef iOSProcessManager_GetCwd = {
 #endif // niMinFeatures(15)
 
 #if niMinFeatures(15)
-// Method: GetEnviron
-static const ni::sMethodDef iOSProcessManager_GetEnviron = {
-  "GetEnviron",
+// Method: GetEnvs
+static const ni::sMethodDef iOSProcessManager_GetEnvs = {
+  "GetEnvs",
   ni::eTypeFlags_MethodGetter|0|ni::eType_IUnknown|ni::eTypeFlags_Pointer, &niGetInterfaceUUID(ni::iCollection), "Ptr<tStringCMap>",
   0, NULL,
 #ifndef niConfig_NoXCALL
-  XCALL_CIMPL(iOSProcessManager_GetEnviron)
+  XCALL_CIMPL(iOSProcessManager_GetEnvs)
 #else
   NULL
 #endif
@@ -20393,7 +20393,7 @@ static const ni::sMethodDef* Methods_iOSProcessManager[] = {
 	&iOSProcessManager_GetCwd,
 #endif // niMinFeatures(15)
 #if niMinFeatures(15)
-	&iOSProcessManager_GetEnviron,
+	&iOSProcessManager_GetEnvs,
 #endif // niMinFeatures(15)
 
 };

--- a/sources/niLang/src/_niLang_ModuleDef.xml
+++ b/sources/niLang/src/_niLang_ModuleDef.xml
@@ -17808,14 +17808,16 @@
 			</method>
 			<method
 				const="yes"
-				java_name="getEnviron"
+				java_name="getEnvs"
 				min_features="15"
-				name="GetEnviron"
+				name="GetEnvs"
 				num_parameters="0"
 				property="get"
-				property_name2="environ"
-				property_name="environ">
-				<comments desc="Get the current environment variables. "/>
+				property_name2="envs"
+				property_name="envs">
+				<comments desc="Get the current environment variables. ">
+					<remark text="This is not named GetEnviron because MSVC has an variable called `environ`. "/>
+				</comments>
 				<return type="Ptr&lt;tStringCMap&gt;" typec="Ptr&lt;tStringCMap&gt;" typei="ni::eType_IUnknown|ni::eTypeFlags_Pointer"/>
 			</method>
 		</interface>

--- a/sources/niLang/tsrc/Test_Process.cpp
+++ b/sources/niLang/tsrc/Test_Process.cpp
@@ -494,11 +494,11 @@ TEST_FIXTURE(FProcess,SpawnPrintLoop) {
 
 TEST_FIXTURE(FProcess,Environ) {
   // astl::map<cString,cString>* environ;
-  Ptr<tStringCMap> environ = _pman->GetEnviron();
-  // for (auto it : *environ) {
+  Ptr<tStringCMap> envs = _pman->GetEnvs();
+  // for (auto it : *envs) {
     // niDebugFmt(("... %s = %s", it.first, it.second));
   // }
-  cString path = astl::get_default(*environ,"PATH","");
+  cString path = astl::get_default(*envs,"PATH","");
   CHECK(path.IsNotEmpty());
 }
 

--- a/sources/niScriptCpp/src/ScriptingHostCpp.cpp
+++ b/sources/niScriptCpp/src/ScriptingHostCpp.cpp
@@ -193,7 +193,7 @@ static tBool ScriptCpp_TryCompileSource(
 
   const cString stamp = _GetStampString(sourceTime);
 
-  Ptr<tStringCMap> envMap = ni::GetOSProcessManager()->GetEnviron();
+  Ptr<tStringCMap> envMap = ni::GetOSProcessManager()->GetEnvs();
   astl::upsert(*envMap, "HAM_HOME", hamHome);
   EnvCopyIfExists(envMap, ni::GetLang(), "CLANG_SANITIZE");
 


### PR DESCRIPTION
## Formal Notes
<!--- NOTE: Release notes are PUBLIC and go into the project's release notes. Other notes are internal. -->
<!--- NOTE: Do NOT mention private/internal info in public RN. -->
<!--- Release note format: RN: MODULE NAME: Adds support for FooFeature. #ISSUE NUMBER -->
<!--- No-release note format: NoRN: Improves or fixes FooThing. -->
<!--- Use RN or NoRN for all the entires. -->
This PR fixes: <!--- (ex: "RN: niScript: Added a basic linter.") -->
*
*
*

<!-- A more detailed description of what's going on. -->
## Description, Motivation and Context
For some unknown reason MSVC can't compile a program that has a local variable named `environ`. On POSIX system that variable contains the current environment variables, on Windows it is named `_environ` & `_wenviron`. But it seems that there's some weird hard coded property of the `environ` variable that the MSVC linker sees which breaks linkage on Windows when using a local variable (yes a local variable, not a global one) that is named environ - note that it doesnt seem to be just another spurious `#define`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include *full* CLI commands -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Command line to run all the tests that I run locally:
```
ham Run_Test_niScript_tu_linter
```

<!---
## Checklist:
* What I did is actually needed (I have a link to an issue and/or a meeting note/wiki doc to prove it)
* I have assigned appropriate labels and projects.
* My code is stylish, commented, and in the right place.
* I have added tests to cover my changes.
* All new and existing tests passed.
* I have updated the documentation appropriately.
-->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [ ] Documentation (code docs, comments, or changes to the doc systems)
- [ ] Testing/Build (test coverage or the test/build subsystems themselves)
- [ ] Packaging (adds examples or modifies a release package)

<!--- This template is stored in .github/PULL_REQUEST_TEMPLATE.md -->
