### PR TITLE
niLang: Add ni::Nonnull, astl::non_null and make ni::Ptr/WeakPtr/QPtr safer ;

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           path: |
             ~/_ham/obj/
             ~/work/niLang/ham
-          key: ${{ runner.os }}-niLang-642fb21-ham-b2a5d4f
+          key: ${{ runner.os }}-niLang-966b290-ham-2ff7d00
 
       - name: Install Ubuntu packages
         run: |

--- a/docs/thirdparty/LICENSE-GSL.txt
+++ b/docs/thirdparty/LICENSE-GSL.txt
@@ -1,0 +1,17 @@
+https://github.com/microsoft/GSL
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////

--- a/sources/niAppLib/src/API/niAppLib.h
+++ b/sources/niAppLib/src/API/niAppLib.h
@@ -61,7 +61,7 @@ struct AppContext : public ni::cMemImpl {
   ni::Ptr<ni::iUIContext>       _uiContext;
 
   ni::tF32 __stdcall GetContentsScale() const {
-    return _config.GetContentsScale(_window);
+    return _config.GetContentsScale(_window.raw_ptr());
   }
 };
 

--- a/sources/niLang/src/API/niLang/IConcurrent.h
+++ b/sources/niLang/src/API/niLang/IConcurrent.h
@@ -338,7 +338,7 @@ inline tBool __stdcall SendMessage(iMessageHandler* apMT, tU32 anID, const Var& 
 inline tBool __stdcall SendMessages(tMessageHandlerSinkLst* apMT, tU32 anID, const Var& avarA = (Var&)niVarNull, const Var& avarB = (Var&)niVarNull) {
   if (!apMT) return eFalse;
   niLoopSink(iMessageHandler,it,apMT) {
-    if (!GetConcurrent()->SendMessage(it->_Value(),anID,avarA,avarB))
+    if (!GetConcurrent()->SendMessage(it->_Value().non_null(),anID,avarA,avarB))
       return eFalse;
   }
   return eTrue;
@@ -353,7 +353,7 @@ inline tBool __stdcall QueueMessage(iMessageHandler* apMT, tU32 anID, const Var&
 inline tBool __stdcall QueueMessages(tMessageHandlerSinkLst* apMT, tU32 anID, const Var& avarA = (Var&)niVarNull, const Var& avarB = (Var&)niVarNull) {
   if (!apMT) return eFalse;
   niLoopSink(iMessageHandler,it,apMT) {
-    if (!GetConcurrent()->QueueMessage(it->_Value(),anID,avarA,avarB))
+    if (!GetConcurrent()->QueueMessage(it->_Value().non_null(),anID,avarA,avarB))
       return eFalse;
   }
   return eTrue;

--- a/sources/niLang/src/API/niLang/IFile.h
+++ b/sources/niLang/src/API/niLang/IFile.h
@@ -7,6 +7,7 @@
 #include "ITime.h"
 #include "IToString.h"
 #include "Utils/SmartPtr.h"
+#include "Utils/Nonnull.h"
 
 namespace ni {
 /** \addtogroup niLang
@@ -734,15 +735,16 @@ struct sWriteBufferToFile {
     if (!_file.IsOK()) {
       return 0;
     }
+    astl::non_null<iFile*> fp = _file.non_null();
     const tSize writeSize = (aCommitSize >= 0) ? aCommitSize : _size;
     tSize r = 0;
     if (writeSize > 0) {
       if (_ownedMemory) {
-        r = _file->WriteRaw(_ownedMemory, writeSize);
+        r = fp->WriteRaw(_ownedMemory, writeSize);
         niFree(_ownedMemory);
       }
       else {
-        _file->Seek(writeSize);
+        fp->Seek(writeSize);
         r = _size;
       }
     }

--- a/sources/niLang/src/API/niLang/Math/MathProb.h
+++ b/sources/niLang/src/API/niLang/Math/MathProb.h
@@ -77,8 +77,8 @@ inline tBool ProbSampleAliasMethod(
   const tF64* q, const tU32* a, const tSize n,
   TRNG&& rngGetNormalizedFloat)
 {
-  niAssert(r && nres >= 1);
-  niAssert(q && a && n >= 1);
+  niCheck(r && nres >= 1, eFalse);
+  niCheck(q && a && n >= 1, eFalse);
 
   const tF64 ndbl = (tF64)n;
   niLoop(i,nres) {
@@ -95,44 +95,43 @@ inline tBool ProbSampleAliasMethod(
 }
 
 template <typename TRNG>
-Ptr<tU32CVec> ProbSampleAliasMethod(
+tBool ProbSampleAliasMethod(
+  astl::non_null<tU32CVec*> r,
   const tSize nres,
-  const ni::tF64CVec* apProbs,
+  astl::non_null<const ni::tF64CVec*> apProbs,
   TRNG&& rngGetNormalizedFloat)
 {
-  niCheck(apProbs && !apProbs->empty(), NULL);
-
+  niCheck(!apProbs->empty(), eFalse);
   // Create the alias arrays used for the prng generation afterward.
-  ni::Ptr<ni::tF64CVec> amq = ni::tF64CVec::Create();
+  ni::Nonnull<ni::tF64CVec> amq(ni::tF64CVec::Create());
   amq->resize(apProbs->size());
-  ni::Ptr<ni::tU32CVec> ama = ni::tU32CVec::Create();
+  ni::Nonnull<ni::tU32CVec> ama(ni::tU32CVec::Create());
   ama->resize(apProbs->size()*2);
   ProbSampleBuildAliasMethodArrays(
     apProbs->data(), apProbs->size(), amq->data(), ama->data());
-
-  ni::Ptr<ni::tU32CVec> r = ni::tU32CVec::Create();
   r->resize(nres);
   ProbSampleAliasMethod(
     r->data(), nres,
     amq->data(), ama->data(), apProbs->size(),
     rngGetNormalizedFloat);
-  return r;
+  return eTrue;
 }
 
-Ptr<tU32CVec> ProbSampleAliasMethod(
+tBool ProbSampleAliasMethod(
+  astl::non_null<tU32CVec*> r,
   const tSize nres,
-  const ni::tF64CVec* apProbs,
+  astl::non_null<const ni::tF64CVec*> apProbs,
   int4* aPRNG = ni_prng_global())
 {
-  niCheck(apProbs && !apProbs->empty(), NULL);
   return ProbSampleAliasMethod(
+    r,
     nres, apProbs,
     [&]() -> ni::tF64 { return ni_prng_next_f64(aPRNG); });
 }
 
 template <typename... Ts>
-ni::Ptr<ni::tF64CVec> ProbArray(Ts... values) {
-  ni::Ptr<ni::tF64CVec> probs = ni::tF64CVec::Create();
+ni::Nonnull<ni::tF64CVec> ProbArray(Ts... values) {
+  ni::Nonnull<ni::tF64CVec> probs(ni::tF64CVec::Create());
   probs->insert(probs->end(), {values...});
   ProbNormalize(probs->data(), probs->size());
   return probs;

--- a/sources/niLang/src/API/niLang/STL/non_null.h
+++ b/sources/niLang/src/API/niLang/STL/non_null.h
@@ -1,0 +1,183 @@
+#pragma once
+#ifndef __NON_NULL_H_A46F1134_B458_8647_8976_5FCF07AB39DD__
+#define __NON_NULL_H_A46F1134_B458_8647_8976_5FCF07AB39DD__
+// SPDX-FileCopyrightText: (c) 2022 The niLang Authors
+// SPDX-License-Identifier: MIT
+
+//
+// Based on gsl::not_null, see thirdparty/LICENSE-GSL.txt
+//
+
+#include "../Types.h"
+#include "EASTL/functional.h"
+#include "EASTL/type_traits.h"
+
+namespace astl {
+
+namespace details {
+template <typename T, typename = void>
+struct is_comparable_to_nullptr : eastl::false_type
+{};
+
+template <typename T>
+struct is_comparable_to_nullptr<
+  T,
+  eastl::enable_if_t<eastl::is_convertible<decltype(eastl::declval<T>() != nullptr), bool>::value>>
+    : eastl::true_type
+{};
+
+} // namespace details
+
+//
+// non_null
+//
+// Restricts a pointer or smart pointer to only hold non-null values.
+//
+// Has zero size overhead over T.
+//
+// If T is a pointer (i.e. T == U*) then
+// - allow construction from U*
+// - disallow construction from nullptr_t
+// - disallow default construction
+// - ensure construction from null U* fails
+// - allow implicit conversion to U*
+//
+template <class T>
+struct non_null
+{
+ public:
+  static_assert(details::is_comparable_to_nullptr<T>::value, "T cannot be compared to nullptr.");
+
+  template <typename U, typename = eastl::enable_if_t<eastl::is_convertible<U, T>::value>>
+  constexpr explicit non_null(U&& u) : ptr_(eastl::forward<U>(u))
+  {
+    niPanicAssert(ptr_ != nullptr);
+  }
+
+  template <typename = eastl::enable_if_t<!eastl::is_same<std::nullptr_t, T>::value>>
+  constexpr explicit non_null(T u) : ptr_(eastl::move(u))
+  {
+    niPanicAssert(ptr_ != nullptr);
+  }
+
+  template <typename U, typename = eastl::enable_if_t<eastl::is_convertible<U, T>::value>>
+  constexpr non_null(const non_null<U>& other) : non_null(other.get())
+  {}
+
+  non_null(non_null&& other) = default;
+  non_null(const non_null& other) = default;
+  non_null& operator=(const non_null& other) = default;
+  constexpr eastl::conditional_t<eastl::is_copy_constructible<T>::value, T, const T&> get() const
+  {
+    EASTL_ASSERT(ptr_ != nullptr);
+    return ptr_;
+  }
+
+  constexpr operator T() const { return get(); }
+  constexpr decltype(auto) operator->() const { return get(); }
+  constexpr decltype(auto) operator*() const { return *get(); }
+
+  // prevents compilation when someone attempts to assign a null pointer constant
+  non_null(std::nullptr_t) = delete;
+  non_null& operator=(std::nullptr_t) = delete;
+
+  // unwanted operators...pointers only point to single objects!
+  non_null& operator++() = delete;
+  non_null& operator--() = delete;
+  non_null operator++(int) = delete;
+  non_null operator--(int) = delete;
+  non_null& operator+=(std::ptrdiff_t) = delete;
+  non_null& operator-=(std::ptrdiff_t) = delete;
+  void operator[](std::ptrdiff_t) const = delete;
+
+ private:
+  T ptr_;
+};
+
+template <class T>
+auto make_non_null(T&& t) noexcept
+{
+  return non_null<eastl::remove_cv_t<eastl::remove_reference_t<T>>>{eastl::forward<T>(t)};
+}
+
+template <class T, class U>
+auto operator==(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.get() == rhs.get()))
+    -> decltype(lhs.get() == rhs.get())
+{
+  return lhs.get() == rhs.get();
+}
+
+template <class T, class U>
+auto operator!=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.get() != rhs.get()))
+    -> decltype(lhs.get() != rhs.get())
+{
+  return lhs.get() != rhs.get();
+}
+
+template <class T, class U>
+auto operator<(const non_null<T>& lhs,
+               const non_null<U>& rhs) noexcept(noexcept(lhs.get() < rhs.get()))
+    -> decltype(lhs.get() < rhs.get())
+{
+  return lhs.get() < rhs.get();
+}
+
+template <class T, class U>
+auto operator<=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.get() <= rhs.get()))
+    -> decltype(lhs.get() <= rhs.get())
+{
+  return lhs.get() <= rhs.get();
+}
+
+template <class T, class U>
+auto operator>(const non_null<T>& lhs,
+               const non_null<U>& rhs) noexcept(noexcept(lhs.get() > rhs.get()))
+    -> decltype(lhs.get() > rhs.get())
+{
+  return lhs.get() > rhs.get();
+}
+
+template <class T, class U>
+auto operator>=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.get() >= rhs.get()))
+    -> decltype(lhs.get() >= rhs.get())
+{
+  return lhs.get() >= rhs.get();
+}
+
+// more unwanted operators
+template <class T, class U>
+std::ptrdiff_t operator-(const non_null<T>&, const non_null<U>&) = delete;
+template <class T>
+non_null<T> operator-(const non_null<T>&, std::ptrdiff_t) = delete;
+template <class T>
+non_null<T> operator+(const non_null<T>&, std::ptrdiff_t) = delete;
+template <class T>
+non_null<T> operator+(std::ptrdiff_t, const non_null<T>&) = delete;
+
+static_assert(sizeof(non_null<int*>) == sizeof(int*), "non_null<> must be the same size as a pointer.");
+
+#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+
+// deduction guides to prevent the ctad-maybe-unsupported warning
+template <class T>
+non_null(T) -> non_null<T>;
+
+#endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
+
+}
+
+namespace eastl {
+
+template <typename T>
+struct hash<astl::non_null<T> > {
+  size_t operator()(const astl::non_null<T>& v) const {
+    return eastl::hash<T>{}(v.get());
+  }
+};
+
+}
+#endif // __NON_NULL_H_A46F1134_B458_8647_8976_5FCF07AB39DD__

--- a/sources/niLang/src/API/niLang/STL/non_null.h
+++ b/sources/niLang/src/API/niLang/STL/non_null.h
@@ -61,21 +61,21 @@ struct non_null
   }
 
   template <typename U, typename = eastl::enable_if_t<eastl::is_convertible<U, T>::value>>
-  constexpr non_null(const non_null<U>& other) : non_null(other.get())
+  constexpr non_null(const non_null<U>& other) : non_null(other.raw_ptr())
   {}
 
   non_null(non_null&& other) = default;
   non_null(const non_null& other) = default;
   non_null& operator=(const non_null& other) = default;
-  constexpr eastl::conditional_t<eastl::is_copy_constructible<T>::value, T, const T&> get() const
+  constexpr eastl::conditional_t<eastl::is_copy_constructible<T>::value, T, const T&> raw_ptr() const
   {
     EASTL_ASSERT(ptr_ != nullptr);
     return ptr_;
   }
 
-  constexpr operator T() const { return get(); }
-  constexpr decltype(auto) operator->() const { return get(); }
-  constexpr decltype(auto) operator*() const { return *get(); }
+  constexpr operator T() const { return raw_ptr(); }
+  constexpr decltype(auto) operator->() const { return raw_ptr(); }
+  constexpr decltype(auto) operator*() const { return *raw_ptr(); }
 
   // prevents compilation when someone attempts to assign a null pointer constant
   non_null(std::nullptr_t) = delete;
@@ -94,60 +94,6 @@ struct non_null
   T ptr_;
 };
 
-template <class T>
-auto make_non_null(T&& t) noexcept
-{
-  return non_null<eastl::remove_cv_t<eastl::remove_reference_t<T>>>{eastl::forward<T>(t)};
-}
-
-template <class T, class U>
-auto operator==(const non_null<T>& lhs,
-                const non_null<U>& rhs) noexcept(noexcept(lhs.get() == rhs.get()))
-    -> decltype(lhs.get() == rhs.get())
-{
-  return lhs.get() == rhs.get();
-}
-
-template <class T, class U>
-auto operator!=(const non_null<T>& lhs,
-                const non_null<U>& rhs) noexcept(noexcept(lhs.get() != rhs.get()))
-    -> decltype(lhs.get() != rhs.get())
-{
-  return lhs.get() != rhs.get();
-}
-
-template <class T, class U>
-auto operator<(const non_null<T>& lhs,
-               const non_null<U>& rhs) noexcept(noexcept(lhs.get() < rhs.get()))
-    -> decltype(lhs.get() < rhs.get())
-{
-  return lhs.get() < rhs.get();
-}
-
-template <class T, class U>
-auto operator<=(const non_null<T>& lhs,
-                const non_null<U>& rhs) noexcept(noexcept(lhs.get() <= rhs.get()))
-    -> decltype(lhs.get() <= rhs.get())
-{
-  return lhs.get() <= rhs.get();
-}
-
-template <class T, class U>
-auto operator>(const non_null<T>& lhs,
-               const non_null<U>& rhs) noexcept(noexcept(lhs.get() > rhs.get()))
-    -> decltype(lhs.get() > rhs.get())
-{
-  return lhs.get() > rhs.get();
-}
-
-template <class T, class U>
-auto operator>=(const non_null<T>& lhs,
-                const non_null<U>& rhs) noexcept(noexcept(lhs.get() >= rhs.get()))
-    -> decltype(lhs.get() >= rhs.get())
-{
-  return lhs.get() >= rhs.get();
-}
-
 // more unwanted operators
 template <class T, class U>
 std::ptrdiff_t operator-(const non_null<T>&, const non_null<U>&) = delete;
@@ -158,7 +104,61 @@ non_null<T> operator+(const non_null<T>&, std::ptrdiff_t) = delete;
 template <class T>
 non_null<T> operator+(std::ptrdiff_t, const non_null<T>&) = delete;
 
+template <class T, class U>
+auto operator==(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() == rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() == rhs.raw_ptr())
+{
+  return lhs.raw_ptr() == rhs.raw_ptr();
+}
+
+template <class T, class U>
+auto operator!=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() != rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() != rhs.raw_ptr())
+{
+  return lhs.raw_ptr() != rhs.raw_ptr();
+}
+
+template <class T, class U>
+auto operator<(const non_null<T>& lhs,
+               const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() < rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() < rhs.raw_ptr())
+{
+  return lhs.raw_ptr() < rhs.raw_ptr();
+}
+
+template <class T, class U>
+auto operator<=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() <= rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() <= rhs.raw_ptr())
+{
+  return lhs.raw_ptr() <= rhs.raw_ptr();
+}
+
+template <class T, class U>
+auto operator>(const non_null<T>& lhs,
+               const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() > rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() > rhs.raw_ptr())
+{
+  return lhs.raw_ptr() > rhs.raw_ptr();
+}
+
+template <class T, class U>
+auto operator>=(const non_null<T>& lhs,
+                const non_null<U>& rhs) noexcept(noexcept(lhs.raw_ptr() >= rhs.raw_ptr()))
+    -> decltype(lhs.raw_ptr() >= rhs.raw_ptr())
+{
+  return lhs.raw_ptr() >= rhs.raw_ptr();
+}
+
 static_assert(sizeof(non_null<int*>) == sizeof(int*), "non_null<> must be the same size as a pointer.");
+
+template <class T>
+auto make_non_null(T&& t) noexcept
+{
+  return non_null<eastl::remove_cv_t<eastl::remove_reference_t<T>>>{eastl::forward<T>(t)};
+}
 
 #if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 
@@ -175,7 +175,7 @@ namespace eastl {
 template <typename T>
 struct hash<astl::non_null<T> > {
   size_t operator()(const astl::non_null<T>& v) const {
-    return eastl::hash<T>{}(v.get());
+    return eastl::hash<T>{}(v.raw_ptr());
   }
 };
 

--- a/sources/niLang/src/API/niLang/Utils/ConcurrentImpl.h
+++ b/sources/niLang/src/API/niLang/Utils/ConcurrentImpl.h
@@ -36,8 +36,8 @@ struct sRunnable : public ni::cIUnknownImpl<iRunnable> {
   virtual Var __stdcall Run() { return _lambda(); }
 };
 template <typename T>
-Ptr<iRunnable> Runnable(const T& aLambda) {
-  return niNew sRunnable<T>(aLambda);
+Nonnull<iRunnable> Runnable(const T& aLambda) {
+  return ni::NewNonnull<sRunnable<T> >(aLambda);
 }
 
 
@@ -51,8 +51,8 @@ struct sCallback0 : public ni::cIUnknownImpl<iCallback,eIUnknownImplFlags_DontIn
   }
 };
 template <typename T>
-Ptr<iCallback> Callback0(const T& aLambda) {
-  return niNew sCallback0<T>(aLambda);
+Nonnull<iCallback> Callback0(const T& aLambda) {
+  return ni::NewNonnull<sCallback0<T> >(aLambda);
 }
 
 template <typename T>
@@ -65,8 +65,8 @@ struct sCallback1 : public ni::cIUnknownImpl<iCallback,eIUnknownImplFlags_DontIn
   }
 };
 template <typename T>
-Ptr<iCallback> Callback1(const T& aLambda) {
-  return niNew sCallback1<T>(aLambda);
+Nonnull<iCallback> Callback1(const T& aLambda) {
+  return ni::NewNonnull<sCallback1<T> >(aLambda);
 }
 
 template <typename T>
@@ -79,8 +79,8 @@ struct sCallback2 : public ni::cIUnknownImpl<iCallback,eIUnknownImplFlags_DontIn
   }
 };
 template <typename T>
-Ptr<iCallback> Callback2(const T& aLambda) {
-  return niNew sCallback2<T>(aLambda);
+Nonnull<iCallback> Callback2(const T& aLambda) {
+  return ni::NewNonnull<sCallback2<T> >(aLambda);
 }
 
 //! To be used with the MessageHandler<> template to specify a function pointer instead of a lambda.
@@ -103,8 +103,8 @@ struct sMessageHandler : public ni::cIUnknownImpl<iMessageHandler> {
 };
 
 template <typename T>
-Ptr<iMessageHandler> MessageHandler(const T& aLambda, const tU64 anThreadID = ni::ThreadGetCurrentThreadID()) {
-  return niNew sMessageHandler<T>(aLambda, anThreadID);
+Nonnull<iMessageHandler> MessageHandler(const T& aLambda, const tU64 anThreadID = ni::ThreadGetCurrentThreadID()) {
+  return ni::NewNonnull<sMessageHandler<T> >(aLambda, anThreadID);
 }
 
 inline tBool IOExecute(iRunnable* apRunnable) {
@@ -154,9 +154,9 @@ struct sConcurrentSubmit {
   template <typename TReleaseFun>
   inline Ptr<iFuture> operator << (TReleaseFun&& afunRelease) {
     if (!_executor) {
-      Ptr<iFutureValue> val = ni::GetConcurrent()->CreateFutureValue();
+      Nonnull<iFutureValue> val { ni::GetConcurrent()->CreateFutureValue() };
       val->SetValue(afunRelease());
-      return (Ptr<iFuture>&)val;
+      return val;
     }
     return _executor->Submit(ni::Runnable(afunRelease));
   }

--- a/sources/niLang/src/API/niLang/Utils/CryptoUtils.h
+++ b/sources/niLang/src/API/niLang/Utils/CryptoUtils.h
@@ -37,7 +37,7 @@ inline Ptr<iCryptoHash> HashString(iCryptoHash* apHash, const achar* aString, co
 
 inline Ptr<iCryptoHash> HashDataTable(iCryptoHash* apHash, iDataTable* apDT) {
   niAssert(niIsOK(apHash));
-  Ptr<iFile> file = GetLang()->CreateFileDynamicMemory(1024, "");
+  Nonnull<iFile> file(GetLang()->CreateFileDynamicMemory(1024, ""));
   if (!GetLang()->SerializeDataTable("dtb",eSerializeMode_Write,apDT,file)) {
     niError("Can't write data table to temporary hash file.");
     return NULL;

--- a/sources/niLang/src/API/niLang/Utils/DataTableUtils.h
+++ b/sources/niLang/src/API/niLang/Utils/DataTableUtils.h
@@ -19,8 +19,9 @@ namespace ni {
 inline Ptr<iDataTable> LoadDataTable(const achar* aURL, const achar* aaszSerFormat = "xml") {
   Ptr<iFile> fp = ni::GetLang()->URLOpen(aURL);
   niCheckIsOK(fp,NULL);
-  Ptr<iDataTable> dt = ni::GetLang()->CreateDataTable("");
-  if (!ni::GetLang()->SerializeDataTable(aaszSerFormat,eSerializeMode_Read,dt,fp)) {
+  Nonnull<iDataTable> dt(ni::GetLang()->CreateDataTable(""));
+  if (!ni::GetLang()->SerializeDataTable(aaszSerFormat,eSerializeMode_Read,
+                                         dt,fp.raw_ptr())) {
     niError(niFmt("Can't read datatable from '%s'.", aURL));
     return NULL;
   }
@@ -35,7 +36,8 @@ inline tBool WriteDataTable(const iDataTable* apDT, const achar* aPath, const ac
     niError(niFmt("Can't open file '%s' to write datatable.", aPath));
     return eFalse;
   }
-  if (!ni::GetLang()->SerializeDataTable(aaszSerFormat,eSerializeMode_Write,(iDataTable*)apDT,fp)) {
+  if (!ni::GetLang()->SerializeDataTable(aaszSerFormat,eSerializeMode_Write,
+                                         (iDataTable*)apDT,fp.raw_ptr())) {
     niError(niFmt("Can't write datatable to '%s'.", aPath));
     return eFalse;
   }
@@ -47,9 +49,11 @@ inline Ptr<iDataTable> CreateDataTableFromXML(const achar* aaszText, tI32 anSize
   if (anSize < 0) {
     anSize = ni::StrSizeZ(aaszText);
   }
-  Ptr<iFile> fp = ni::GetLang()->CreateFileMemory((tPtr)aaszText,anSize,eFalse,"::CreateDataTableFromXML");
-  Ptr<iDataTable> dt = ni::GetLang()->CreateDataTable("");
-  if (!ni::GetLang()->SerializeDataTable("xml",eSerializeMode_Read,dt,fp))
+  Nonnull<iFile> fp(ni::GetLang()->CreateFileMemory(
+    (tPtr)aaszText,anSize,eFalse,"::CreateDataTableFromXML"));
+  Nonnull<iDataTable> dt(ni::GetLang()->CreateDataTable(""));
+  if (!ni::GetLang()->SerializeDataTable("xml",eSerializeMode_Read,
+                                         dt,fp))
     return NULL;
   return dt;
 }
@@ -57,7 +61,7 @@ inline Ptr<iDataTable> CreateDataTableFromXML(const achar* aaszText, tI32 anSize
 ///////////////////////////////////////////////
 inline cString DataTableToXML(iDataTable* apDT, tBool abStream = eTrue) {
   niCheckIsOK(apDT,"");
-  Ptr<iFile> fp = ni::GetLang()->CreateFileDynamicMemory();
+  Nonnull<iFile> fp(ni::GetLang()->CreateFileDynamicMemory());
   if (!ni::GetLang()->SerializeDataTable(abStream ? "xml-stream" : "xml",eSerializeMode_Write,apDT,fp))
     return AZEROSTR;
   fp->SeekSet(0);
@@ -70,10 +74,10 @@ static const char* _kDataTableCompressedStringMode = "xml-stream";
 ///////////////////////////////////////////////
 inline cString DataTableToCompressedString(iDataTable* apDT) {
   niCheckIsOK(apDT,"");
-  Ptr<iFile> fp = ni::GetLang()->CreateFileDynamicMemory();
+  Nonnull<iFile> fp(ni::GetLang()->CreateFileDynamicMemory());
 
   {
-    Ptr<iFile> fpXml = ni::GetLang()->CreateFileDynamicMemory();
+    Nonnull<iFile> fpXml(ni::GetLang()->CreateFileDynamicMemory());
     if (!ni::GetLang()->SerializeDataTable(_kDataTableCompressedStringMode,eSerializeMode_Write,apDT,fpXml))
       return AZEROSTR;
     fpXml->SeekSet(0);
@@ -89,12 +93,12 @@ inline cString DataTableToCompressedString(iDataTable* apDT) {
 
 ///////////////////////////////////////////////
 inline Ptr<iDataTable> CreateDataTableFromCompressedString(const achar* aaszText) {
-  Ptr<iFile> fpDecodedBytes = ni::GetLang()->CreateFileDynamicMemory();
+  Nonnull<iFile> fpDecodedBytes(ni::GetLang()->CreateFileDynamicMemory());
   fpDecodedBytes->WriteRawFromString(eRawToStringEncoding_Base64, aaszText);
   if (!fpDecodedBytes->GetSize())
     return NULL;
 
-  Ptr<iFile> fp = ni::GetLang()->CreateFileDynamicMemory();
+  Nonnull<iFile> fp(ni::GetLang()->CreateFileDynamicMemory());
   {
     tPtr output = fpDecodedBytes->GetBase();
     tU32 decompressedSize = *(tU32*)output;
@@ -103,8 +107,9 @@ inline Ptr<iDataTable> CreateDataTableFromCompressedString(const achar* aaszText
     fp->SeekSet(0);
   }
 
-  Ptr<iDataTable> dt = ni::GetLang()->CreateDataTable("");
-  if (!ni::GetLang()->SerializeDataTable(_kDataTableCompressedStringMode,eSerializeMode_Read,dt,fp))
+  Nonnull<iDataTable> dt(ni::GetLang()->CreateDataTable(""));
+  if (!ni::GetLang()->SerializeDataTable(
+        _kDataTableCompressedStringMode,eSerializeMode_Read,dt,fp))
     return NULL;
 
   return dt;

--- a/sources/niLang/src/API/niLang/Utils/Nonnull.h
+++ b/sources/niLang/src/API/niLang/Utils/Nonnull.h
@@ -1,0 +1,211 @@
+#pragma once
+#ifndef __REF_H_E82A7EBA_7FCF_2845_98FF_920CC296C3CF__
+#define __REF_H_E82A7EBA_7FCF_2845_98FF_920CC296C3CF__
+// SPDX-FileCopyrightText: (c) 2022 The niLang Authors
+// SPDX-License-Identifier: MIT
+#include "../Types.h"
+#include "../STL/maybe.h"
+#include "../STL/non_null.h"
+#include "SmartPtr.h"
+
+namespace ni {
+/** \addtogroup niLang
+ * @{
+ */
+/** \addtogroup niLang_Ptr
+ * @{
+ */
+
+//! A strong reference pointer to an iUnknown object that can never be null.
+template <typename T>
+struct Nonnull
+{
+  niClassNoHeapAlloc(Nonnull);
+
+ public:
+  typedef astl::non_null<T*> non_null_t;
+  typedef astl::non_null<const T*> const_non_null_t;
+
+  // Explicit so that its clear at callsites that it will enforce it to be
+  // non-null.
+  explicit Nonnull(const T* aPtr) {
+    mRefPtr = niConstCast(T*,aPtr);
+    niPanicAssert(niIsOK(mRefPtr));
+    ni::AddRef(mRefPtr);
+  }
+
+  Nonnull(const Nonnull<T>& aRight) {
+    // Call the copy operator
+    *this = aRight;
+  }
+
+  Nonnull(Nonnull<T>&& aRight) {
+    // Call the move operator
+    *this = astl::move(aRight);
+  }
+
+  ~Nonnull() {
+    // mRefPtr can be nulled by the move operator
+    if (mRefPtr != NULL) {
+      ni::Release(mRefPtr);
+    }
+  }
+
+  // Copy operator
+  Nonnull& operator = (const Nonnull<T>& aRight) {
+    niPanicAssert(niIsOK(aRight.mRefPtr));
+    mRefPtr = aRight.mRefPtr;
+    ni::AddRef(mRefPtr);
+    return *this;
+  }
+
+  // Move operator
+  Nonnull& operator = (Nonnull<T>&& aRight) {
+    niPanicAssert(niIsOK(aRight.mRefPtr));
+    mRefPtr = aRight.mRefPtr;
+    aRight.mRefPtr = NULL;
+    return *this;
+  }
+
+  // Casting to a non_null pointer.
+  operator non_null_t () const {
+    return ptr();
+  }
+
+  // Casting to a T* pointer.
+  operator T* () const {
+    return mRefPtr;
+  }
+
+  // Casting to a non_null<const T*> pointer
+  template <
+    typename U = T,
+    typename eastl::enable_if<!std::is_const<U>::value,int>::type* = nullptr>
+  operator const_non_null_t () const {
+    return c_ptr();
+  }
+
+  // Casting to a const T* pointer.
+  template <
+    typename U = T,
+    typename eastl::enable_if<!std::is_const<U>::value,int>::type* = nullptr>
+  operator const T* () const {
+    return const_cast<const T*>(mRefPtr);
+  }
+
+  // Dereference operator
+  T& operator * () const {
+    niDebugAssert(niIsOK(mRefPtr));
+    return *mRefPtr;
+  }
+
+  // Arrow operator, allow to use regular C syntax to access members of class.
+  T* operator -> (void) const {
+    niDebugAssert(niIsOK(mRefPtr));
+    return mRefPtr;
+  }
+
+  // shared_ptr like accessors
+  non_null_t ptr() const {
+    niDebugAssert(niIsOK(mRefPtr));
+    return niCCast(astl::non_null<T*>&,mRefPtr);
+  }
+  const_non_null_t c_ptr() const {
+    niDebugAssert(niIsOK(mRefPtr));
+    return niCCast(astl::non_null<const T*>&,mRefPtr);
+  }
+
+ private:
+  Nonnull() = delete;
+  Nonnull& operator = (T* newp);
+
+  // To confuse the compiler if someone tries to delete the object
+  operator void* () const;
+
+  // Cannot be non_null because we allow mRefPtr to be set to NULL on move
+  T* mRefPtr;
+};
+
+niCAssert(sizeof(Nonnull<iUnknown>) == sizeof(Ptr<iUnknown>));
+
+template<class T, class U> inline bool operator==(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() == b.ptr();
+}
+template<class T, class U> inline bool operator!=(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() != b.ptr();
+}
+template<class T, class U> inline bool operator<(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() < b.ptr();
+}
+template<class T, class U> inline bool operator>(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() > b.ptr();
+}
+template<class T, class U> inline bool operator<=(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() <= b.ptr();
+}
+template<class T, class U> inline bool operator>=(Nonnull<T> const& a, Nonnull<U> const& b) {
+  return a.ptr() >= b.ptr();
+}
+
+template <typename T>
+using MaybePtr = astl::maybe<ni::Nonnull<T> >;
+
+template <typename T, typename... Args>
+inline EA_CONSTEXPR ni::Nonnull<T> NewNonnull(Args&&... args) {
+  return ni::Nonnull<T>(niNew T(eastl::forward<Args>(args)...));
+}
+
+template <typename T>
+inline EA_CONSTEXPR Nonnull<T> MakeNonnull(T* v) {
+  return Nonnull<T>(v);
+}
+
+template <typename T>
+inline EA_CONSTEXPR MaybePtr<T> JustNonnull(T* v) {
+  return astl::just(Nonnull<T>(v));
+}
+template <typename T>
+inline EA_CONSTEXPR MaybePtr<T> JustNonnull(const Ptr<T>& v) {
+  return JustNonnull(v.ptr());
+}
+
+template <typename T, typename... Args>
+inline EA_CONSTEXPR MaybePtr<T> NewMaybePtr(Args&&... args) {
+  return JustNonnull(niNew T(eastl::forward<Args>(args)...));
+}
+
+template <typename T>
+inline EA_CONSTEXPR MaybePtr<T> MakeMaybePtr(T* v) {
+  if (v == nullptr) {
+    return ASTL_NOTHING;
+  }
+  else {
+    return JustNonnull<T>(v);
+  }
+}
+template <typename T>
+inline EA_CONSTEXPR MaybePtr<T> MakeMaybePtr(const Ptr<T>& v) {
+  return MakeMaybePtr(v.ptr());
+}
+
+template <typename T>
+inline EA_CONSTEXPR astl::maybe<ni::Nonnull<const T> >& ConstMaybePtr(const MaybePtr<T>& v) {
+  return niCCast(astl::maybe<ni::Nonnull<const T> >&,v);
+}
+
+/**@}*/
+/**@}*/
+}; // End of ni
+
+namespace eastl {
+
+template <typename T>
+struct hash<ni::Nonnull<T> > {
+  size_t operator()(const ni::Nonnull<T>& v) const {
+    return eastl::hash<typename ni::Nonnull<T>::non_null_t>{}(v.ptr());
+  }
+};
+
+}
+/// EOF //////////////////////////////////////////////////////////////////////////////////////
+#endif // __REF_H_E82A7EBA_7FCF_2845_98FF_920CC296C3CF__

--- a/sources/niLang/src/API/niLang/Utils/SmartPtr.h
+++ b/sources/niLang/src/API/niLang/Utils/SmartPtr.h
@@ -149,12 +149,6 @@ ni::Ptr<T>& cast_ptr(ni::Ptr<I>& aPtr) {
   return (ni::Ptr<T>&)aPtr;
 }
 
-//! Member pointer is a smart pointer that requires to be initialized when constructed.
-template <typename T>
-struct MemberPointer : public Ptr<T> {
-  MemberPointer(T* apM) : Ptr<T>(apM) {}
-};
-
 /// EOF //////////////////////////////////////////////////////////////////////////////////////
 /**@}*/
 /**@}*/

--- a/sources/niLang/src/API/niLang/Utils/SmartPtr.h
+++ b/sources/niLang/src/API/niLang/Utils/SmartPtr.h
@@ -2,6 +2,8 @@
 #define __SMARTPTR_24481621_H__
 // SPDX-FileCopyrightText: (c) 2022 The niLang Authors
 // SPDX-License-Identifier: MIT
+#include "Nonnull.h"
+
 namespace ni {
 /** \addtogroup niLang
  * @{
@@ -13,6 +15,12 @@ namespace ni {
 template <typename T>
 struct WeakPtr;
 
+#if !defined niNoUnsafePtr
+#define niPtr_HasUnsafeAPI
+#else
+#define niPtr_NoUnsafeAPI
+#endif
+
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 struct Ptr
@@ -21,20 +29,45 @@ struct Ptr
 
  public:
   Ptr() : mPtr(NULL) {}
+
   Ptr(const T* _p) {
     mPtr = niConstCast(T*,_p);
     if (mPtr)
-      mPtr->AddRef();
+      ni::AddRef(mPtr);
   }
   Ptr(const Ptr<T>& _p) : mPtr(_p.mPtr) {
     if (mPtr)
-      mPtr->AddRef();
+      ni::AddRef(mPtr);
   }
   Ptr(const WeakPtr<T>& aP);
 
+  Ptr(const astl::non_null<T*>& aRight) {
+    mPtr = niConstCast(T*,aRight.raw_ptr());
+    ni::AddRef(mPtr);
+  }
+  template <typename U,
+            typename = eastl::enable_if_t<
+              eastl::is_convertible<U*, T*>::value>>
+  Ptr(const astl::non_null<U*>& aU) {
+    mPtr = niConstCast(U*,aU.raw_ptr());
+    ni::AddRef(mPtr);
+  }
+
+  Ptr(const Nonnull<T>& aRight) {
+    mPtr = niConstCast(T*,aRight.raw_ptr());
+    ni::AddRef(mPtr);
+  }
+  template <typename U,
+            typename = eastl::enable_if_t<
+              eastl::is_convertible<U*, T*>::value>>
+  Ptr(const Nonnull<U>& aU) {
+    mPtr = niConstCast(U*,aU.raw_ptr());
+    ni::AddRef(mPtr);
+  }
+
   ~Ptr()  {
     if (mPtr)
-      mPtr->Release();
+      ni::Release(mPtr);
   }
 
   // Assignment operator
@@ -42,8 +75,16 @@ struct Ptr
     Swap(newp);
     return *this;
   }
-  Ptr&  operator = (const Ptr<T> &newp) {
+  Ptr& operator = (const Ptr<T> &newp) {
     Swap(newp.mPtr);
+    return *this;
+  }
+  Ptr& operator = (const astl::non_null<T*> &newp) {
+    Swap(newp.raw_ptr());
+    return *this;
+  }
+  Ptr& operator = (const Nonnull<T> &newp) {
+    Swap(newp.raw_ptr());
     return *this;
   }
 
@@ -52,6 +93,7 @@ struct Ptr
     return mPtr != NULL && mPtr->IsOK();
   }
 
+#if defined niPtr_HasUnsafeAPI
   // Casting to a normal pointer.
   operator T* () const {
     return mPtr;
@@ -68,19 +110,21 @@ struct Ptr
     niAssert(mPtr != NULL);
     return mPtr;
   }
+#endif
 
   // Replace pointer.
   void Swap(const T* apPointer) {
     T* newp = (T*)apPointer;
     if (newp != mPtr) {
       if (newp)
-        newp->AddRef();
+        ni::AddRef(newp);
       if (mPtr)
-        mPtr->Release();
+        ni::Release(mPtr);
     }
     mPtr = newp;
   }
 
+#if defined niPtr_HasUnsafeAPI
   //! Null the smart pointer and return it's contained pointer.
   //! \remark This method makes sure that the pointer returned is not released.
   //!     It can return zero reference objects.
@@ -92,6 +136,7 @@ struct Ptr
     rawPtr->SetNumRefs(rawPtr->GetNumRefs()-1000);
     return rawPtr;
   }
+#endif
 
   // shared_ptr like accessors
   T* ptr() const { return const_cast<T*>(mPtr);  }
@@ -99,36 +144,135 @@ struct Ptr
 
   void swap(T* newp) { this->Swap(newp); }
 
+  tBool is_null() const {
+    return mPtr == nullptr;
+  }
+  tBool has_value() const {
+    return mPtr != nullptr;
+  }
+  ni::Nonnull<T>& non_null() const {
+    niPanicAssert(mPtr != nullptr);
+    return niCCast(Nonnull<T>&,*this);
+  }
+  ni::Nonnull<const T>& c_non_null() const {
+    niPanicAssert(mPtr != nullptr);
+    return niCCast(Nonnull<const T>&,*this);
+  }
+
+  T* raw_ptr() const {
+    return const_cast<T*>(mPtr);
+  }
+
+  ni::Ptr<const T>& ToConst() const {
+    niPanicAssert(mPtr != nullptr);
+    return (ni::Ptr<const T>&)*this;
+  }
+
  private:
   // Prevent if (PTR), if (!PTR), if (PTR == 0/NULL), if (PTR != 0/NULL)
-  operator bool () const;
-  bool operator !() const;
-  bool operator == (int) const;
-  bool operator != (int) const;
+  operator bool () const = delete;
+  bool operator !() const = delete;
+  bool operator == (int) const = delete;
+  bool operator != (int) const = delete;
 
   // To confuse the compiler if someone tries to delete the smart pointer
-  operator void* () const;
+  operator void* () const = delete;
+
+  // unwanted operators...pointers only point to single objects!
+  Ptr& operator++() = delete;
+  Ptr& operator--() = delete;
+  Ptr operator++(int) = delete;
+  Ptr operator--(int) = delete;
+  Ptr& operator+=(std::ptrdiff_t) = delete;
+  Ptr& operator-=(std::ptrdiff_t) = delete;
+  void operator[](std::ptrdiff_t) const = delete;
 
   T* mPtr;
 };
 
-template<class T, class U> inline bool operator==(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() == b.ptr();
+// more unwanted operators
+template <class T, class U>
+std::ptrdiff_t operator-(const Ptr<T>&, const Ptr<U>&) = delete;
+template <class T>
+Ptr<T> operator-(const Ptr<T>&, std::ptrdiff_t) = delete;
+template <class T>
+Ptr<T> operator+(const Ptr<T>&, std::ptrdiff_t) = delete;
+template <class T>
+Ptr<T> operator+(std::ptrdiff_t, const Ptr<T>&) = delete;
+
+template<class T, class U>
+inline bool operator==(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() == b.raw_ptr();
 }
-template<class T, class U> inline bool operator!=(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() != b.ptr();
+template<class T, class U>
+inline bool operator!=(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() != b.raw_ptr();
 }
-template<class T, class U> inline bool operator<(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() < b.ptr();
+template<class T, class U>
+inline bool operator<(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() < b.raw_ptr();
 }
-template<class T, class U> inline bool operator>(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() > b.ptr();
+template<class T, class U>
+inline bool operator>(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() > b.raw_ptr();
 }
-template<class T, class U> inline bool operator<=(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() <= b.ptr();
+template<class T, class U>
+inline bool operator<=(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() <= b.raw_ptr();
 }
-template<class T, class U> inline bool operator>=(Ptr<T> const& a, Ptr<U> const& b) {
-  return a.ptr() >= b.ptr();
+template<class T, class U>
+inline bool operator>=(Ptr<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() >= b.raw_ptr();
+}
+
+template<class T, class U>
+inline bool operator==(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() == b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator!=(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() != b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator<(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() < b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator>(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() > b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator<=(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() <= b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator>=(Ptr<T> const& a, Nonnull<U> const& b) {
+  return a.raw_ptr() >= b.raw_ptr();
+}
+
+template<class T, class U>
+inline bool operator==(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() == b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator!=(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() != b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator<(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() < b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator>(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() > b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator<=(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() <= b.raw_ptr();
+}
+template<class T, class U>
+inline bool operator>=(Nonnull<T> const& a, Ptr<U> const& b) {
+  return a.raw_ptr() >= b.raw_ptr();
 }
 
 template <typename T>
@@ -147,6 +291,16 @@ ni::Ptr<T>& cast_ptr(ni::Ptr<I>& aPtr) {
   T* r = aPtr.ptr();
   (void)r;
   return (ni::Ptr<T>&)aPtr;
+}
+
+template <typename T, typename... Args>
+inline EA_CONSTEXPR ni::Ptr<T> NewPtr(Args&&... args) {
+  return ni::Ptr<T>(niNew T(eastl::forward<Args>(args)...));
+}
+
+template <typename T>
+inline EA_CONSTEXPR Ptr<T> MakePtr(T* v) {
+  return Ptr<T>(v);
 }
 
 /// EOF //////////////////////////////////////////////////////////////////////////////////////

--- a/sources/niLang/src/API/niLang/Utils/Sync.h
+++ b/sources/niLang/src/API/niLang/Utils/Sync.h
@@ -2,9 +2,10 @@
 #define __SYNC_31981078_H__
 // SPDX-FileCopyrightText: (c) 2022 The niLang Authors
 // SPDX-License-Identifier: MIT
-#include "../Utils/ThreadImpl.h"
+#include "ThreadImpl.h"
 #include "BoxedTypes.h"
 #include "SyncPtr.h"
+#include "Nonnull.h"
 
 /** \addtogroup niLang
  * @{

--- a/sources/niLang/src/API/niLang/Utils/WeakPtr.h
+++ b/sources/niLang/src/API/niLang/Utils/WeakPtr.h
@@ -70,6 +70,19 @@ struct WeakPtr {
     return (tIntPtr)mWeakPtrObject.ptr();
   }
 
+  tBool is_null() const {
+    return mWeakPtrObject.raw_ptr() == nullptr;
+  }
+  tBool has_value() const {
+    return mWeakPtrObject.raw_ptr() != nullptr;
+  }
+  ni::Nonnull<T> non_null() const {
+    return ni::MakeNonnull(mWeakPtrObject.raw_ptr());
+  }
+  ni::Nonnull<const T> c_non_null() const {
+    return ni::MakeNonnull(mWeakPtrObject.raw_ptr());
+  }
+
  private:
   Ptr<iUnknown> mWeakPtrObject;
 
@@ -87,7 +100,26 @@ struct WeakPtr {
 
   // To confuse the compiler if someone tries to delete the smart pointer
   operator void* () const;
+
+  // unwanted operators...pointers only point to single objects!
+  WeakPtr& operator++() = delete;
+  WeakPtr& operator--() = delete;
+  WeakPtr operator++(int) = delete;
+  WeakPtr operator--(int) = delete;
+  WeakPtr& operator+=(std::ptrdiff_t) = delete;
+  WeakPtr& operator-=(std::ptrdiff_t) = delete;
+  void operator[](std::ptrdiff_t) const = delete;
 };
+
+// more unwanted operators
+template <class T, class U>
+std::ptrdiff_t operator-(const WeakPtr<T>&, const WeakPtr<U>&) = delete;
+template <class T>
+WeakPtr<T> operator-(const WeakPtr<T>&, std::ptrdiff_t) = delete;
+template <class T>
+WeakPtr<T> operator+(const WeakPtr<T>&, std::ptrdiff_t) = delete;
+template <class T>
+WeakPtr<T> operator+(std::ptrdiff_t, const WeakPtr<T>&) = delete;
 
 template <typename T>
 __forceinline bool IsNullPtr(WeakPtr<T> const& a) {
@@ -112,12 +144,6 @@ template<class T, class U> inline bool operator<=(WeakPtr<T> const& a, WeakPtr<U
 template<class T, class U> inline bool operator>=(WeakPtr<T> const& a, WeakPtr<U> const& b) {
   return a.__GetWeakObjecIntPtr() >= b.__GetWeakObjecIntPtr();
 }
-
-//! MemberWeakPtr is a weak pointer that requires to be initialized when constructed.
-template <typename T>
-struct MemberWeakPtr : public WeakPtr<T> {
-  MemberWeakPtr(T* apM) : WeakPtr<T>(apM) {}
-};
 
 template<class T>
 inline Ptr<T>::Ptr(const WeakPtr<T>& aP) {

--- a/sources/niLang/src/API/niLang/Var.h
+++ b/sources/niLang/src/API/niLang/Var.h
@@ -340,6 +340,28 @@ struct Var : public VarData
     return *this;
   }
 
+  template <typename S>
+  Var(const astl::non_null<S>& aP) {
+    mType = eType_Null;
+    SetIUnknownPointer(aP.raw_ptr());
+  }
+  template <typename S>
+  Var& operator = (const astl::non_null<S>& aP) {
+    SetIUnknownPointer(aP.raw_ptr());
+    return *this;
+  }
+
+  template <typename S>
+  Var(const Nonnull<S>& aP) {
+    mType = eType_Null;
+    SetIUnknownPointer(aP.raw_ptr());
+  }
+  template <typename S>
+  Var& operator = (const Nonnull<S>& aP) {
+    SetIUnknownPointer(aP.raw_ptr());
+    return *this;
+  }
+
   inline void SetIUnknownPointer(iUnknown* anV) {
     if (IsIUnknownPointer() && mpIUnknown == anV)
       return;

--- a/sources/niLang/src/Console.h
+++ b/sources/niLang/src/Console.h
@@ -88,10 +88,10 @@ class cConsole : public cIUnknownImpl<iConsole>
   tNamespaceMap mmapNamespaces;
   sNamespace    mGlobalNamespace;
 
-  tU32  mulCompleteCmdLineCount;
+  tU32 mulCompleteCmdLineCount;
   cString mstrLastCompletedCommand;
 
-  MemberPointer<tConsoleSinkLst>  msinkList;
+  Nonnull<tConsoleSinkLst> msinkList;
 
   typedef astl::deque<cString> tCmdQueue;
   tCmdQueue mCmdQueue;

--- a/sources/niLang/src/ConsoleCommands_Global.cpp
+++ b/sources/niLang/src/ConsoleCommands_Global.cpp
@@ -149,7 +149,7 @@ niGlobalCommand(ListScriptingHosts,_A("Show the list of the registered Scripting
     iScriptingHost* pHost = ni::GetLang()->GetScriptingHost(i);
     if (pHost) {
       niLog(Info,niFmt(_A("  %s = 0x%x"), niHStr(hspName), pHost));
-      MemberPointer<tUUIDCVec> uuidLst = tUUIDCVec::Create();
+      Nonnull<tUUIDCVec> uuidLst(tUUIDCVec::Create());
       pHost->ListInterfaces(uuidLst,0);
       tBool first = eTrue;
       cString itfs = _A("  - interfaces: ");

--- a/sources/niLang/src/Lang.h
+++ b/sources/niLang/src/Lang.h
@@ -254,7 +254,7 @@ class cLang : public cIUnknownImpl<iLang,eIUnknownImplFlags_NoRefCount|eIUnknown
   tU32 __stdcall GetModuleDefIndex(const achar* aaszName) const niImpl;
   const iModuleDef* __stdcall LoadModuleDef(const achar* aMID, const achar* aaszFile = NULL) niImpl;
 
-  MemberPointer<tCreateInstanceCMap> mmapCreateInstance;
+  Nonnull<tCreateInstanceCMap> mmapCreateInstance;
   tCreateInstanceCMap* __stdcall GetCreateInstanceMap() const {
     return mmapCreateInstance;
   }
@@ -262,7 +262,7 @@ class cLang : public cIUnknownImpl<iLang,eIUnknownImplFlags_NoRefCount|eIUnknown
       const achar* aOID,
       const Var& aVarA = niVarNull, const Var& aVarB = niVarNull) niImpl;
 
-  MemberPointer<tGlobalInstanceCMap> mmapGlobalInstance;
+  Nonnull<tGlobalInstanceCMap> mmapGlobalInstance;
   tGlobalInstanceCMap* __stdcall GetGlobalInstanceMap() const {
     return mmapGlobalInstance;
   }

--- a/sources/niLang/src/System_Win32.cpp
+++ b/sources/niLang/src/System_Win32.cpp
@@ -2087,7 +2087,7 @@ class cOSWindowWindows : public ni::cIUnknownImpl<ni::iOSWindow,
   tBool                                   mbRequestedClose;
   tBool                                   mbDropTarget;
   tBool                                   mbBackgroundUpdate;
-  MemberPointer<tOSWindowWindowsSinkList> mlstSinks;
+  Nonnull<tOSWindowWindowsSinkList>      mlstSinks;
 #ifdef USE_IDROPTARGET
   cWin32DropTarget*                       mpDropTarget;
 #endif

--- a/sources/niLang/tsrc/Test_AccurateSleep.cpp
+++ b/sources/niLang/tsrc/Test_AccurateSleep.cpp
@@ -2,6 +2,8 @@
 #include "../src/API/niLang/Utils/TimerSleep.h"
 #include "../src/API/niLang/Utils/DataTableUtils.h"
 
+namespace {
+
 struct FAccurateSleep {};
 
 struct sSleepData {
@@ -13,9 +15,7 @@ struct sSleepData {
   ni::tF64 maxerr  = -INFINITY; // maximum error we had
 };
 
-namespace ni {
-
-ni::iDataTable* ToDataTable(iDataTable* apDT, const sSleepData& aData) {
+ni::iDataTable* ToDataTable(ni::iDataTable* apDT, const sSleepData& aData) {
   niCheckIsOK(apDT,NULL);
   apDT->SetInt("sampleSize", aData.sampleSize);
   apDT->SetFloat("target", aData.target);
@@ -24,8 +24,6 @@ ni::iDataTable* ToDataTable(iDataTable* apDT, const sSleepData& aData) {
   apDT->SetFloat("minerr", aData.minerr);
   apDT->SetFloat("maxerr", aData.maxerr);
   return apDT;
-}
-
 }
 
 sSleepData _MeasureAccuracy(void (*aSleep)(ni::tF64 aSecs),
@@ -70,7 +68,7 @@ TEST_FIXTURE(FAccurateSleep, MeasureAccuracy_SleepSecsCoarse) {
   dt->SetString("functionName","SleepSecsCoarse");
   niDebugFmt(("... SleepOs: %s",
               ni::DataTableToXML(
-                ni::ToDataTable(dt,data),
+                ToDataTable(dt,data),
                 ni::eFalse)));
 #ifdef niWindows
   // expect 15ms error max
@@ -91,7 +89,7 @@ TEST_FIXTURE(FAccurateSleep, MeasureAccuracy_SleepSecsSpin) {
   dt->SetString("functionName","SleepSecsSpin");
   niDebugFmt(("... SleepSpin: %s",
               ni::DataTableToXML(
-                ni::ToDataTable(dt,data),
+                ToDataTable(dt,data),
                 ni::eFalse)));
   // expect 15us error max
   CHECK_LE(data.meanerr, 2e-5);
@@ -107,8 +105,10 @@ TEST_FIXTURE(FAccurateSleep, MeasureAccuracy_SleepSecs) {
   dt->SetString("functionName","SleepSecs (Precise)");
   niDebugFmt(("... SleepPrecise: %s",
               ni::DataTableToXML(
-                ni::ToDataTable(dt,data),
+                ToDataTable(dt,data),
                 ni::eFalse)));
   // expect 20us error max
   CHECK_LE(data.meanerr, 2e-5);
 }
+
+} // end of anonymous namespace

--- a/sources/niLang/tsrc/Test_JSCC.cpp
+++ b/sources/niLang/tsrc/Test_JSCC.cpp
@@ -6,7 +6,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
-namespace ni {
+namespace {
 
 struct FJSCC {
 };
@@ -214,5 +214,5 @@ TEST_FIXTURE(FJSCC,OpenGL) {
   }
 }
 
-} // end of namespace ni
+} // end of anonymous namespace
 #endif

--- a/sources/niLang/tsrc/Test_Math.cpp
+++ b/sources/niLang/tsrc/Test_Math.cpp
@@ -110,11 +110,12 @@ TEST_FIXTURE(FMath,ProbRaw) {
 }
 
 TEST_FIXTURE(FMath,ProbHL) {
-  ni::Ptr<ni::tF64CVec> probs = ProbArray(0.1, 15.0, 50.0, 65.0, 85.0);
+  ni::Nonnull<ni::tF64CVec> probs = ProbArray(0.1, 15.0, 50.0, 65.0, 85.0);
 
   ni::int4 prng = ni_prng_init(123);
   const tU32 knPickCount = 7000;
-  Ptr<tU32CVec> r = ProbSampleAliasMethod(knPickCount, probs, &prng);
+  Nonnull<tU32CVec> r{tU32CVec::Create()};
+  ProbSampleAliasMethod(r, knPickCount, probs, &prng);
   CHECK_EQUAL(knPickCount, r->size());
 
   // Check the results

--- a/sources/niLang/tsrc/Test_Nonnull.cpp
+++ b/sources/niLang/tsrc/Test_Nonnull.cpp
@@ -1,0 +1,115 @@
+#include "stdafx.h"
+#include <niLang/Utils/Nonnull.h>
+#include <niLang/STL/set.h>
+#include <niLang/STL/hash_set.h>
+
+using namespace ni;
+
+struct FNonnull {};
+
+struct sTestItem : public cIUnknownImpl<iUnknown> {
+  sTestItem(const achar* aName)
+      : _name(aName)
+  {}
+  ni::cString _name;
+};
+
+ni::cString TestNonnull(astl::non_null<sTestItem*> v) {
+  return v->_name;
+}
+ni::cString TestConstNonnull(astl::non_null<const sTestItem*> v) {
+  return v->_name;
+}
+
+TEST_FIXTURE(FNonnull,non_null) {
+  int value = 123;
+  astl::non_null<int*> v { &value };
+  CHECK_EQUAL(value, *v);
+}
+
+TEST_FIXTURE(FNonnull,non_null_hash_set) {
+  int a = 123;
+  int b = 456;
+
+  astl::hash_set<astl::non_null<const int*> > hashedSet;
+  hashedSet.insert(astl::make_non_null(&a));
+  hashedSet.insert(astl::make_non_null(&b));
+  CHECK(astl::contains(hashedSet, astl::make_non_null(&a)));
+  CHECK(astl::contains(hashedSet, astl::make_non_null(&b)));
+}
+
+TEST_FIXTURE(FNonnull,base) {
+  Nonnull<sTestItem> itemA = ni::NewNonnull<sTestItem>("fooItem");
+  CHECK_NOT_EQUAL(nullptr, (sTestItem*&)itemA);
+  CHECK_EQUAL(1, itemA->GetNumRefs());
+  CHECK_EQUAL(_ASTR("fooItem"), itemA->_name);
+  CHECK_EQUAL(_ASTR("fooItem"), TestNonnull(itemA));
+  CHECK_EQUAL(_ASTR("fooItem"), TestNonnull(itemA.ptr()));
+  CHECK_EQUAL(_ASTR("fooItem"), TestConstNonnull(itemA));
+  CHECK_EQUAL(_ASTR("fooItem"), TestConstNonnull(itemA.c_ptr()));
+}
+
+TEST_FIXTURE(FNonnull,move) {
+  Nonnull<sTestItem> itemA = ni::NewNonnull<sTestItem>("fooItem");
+  CHECK_NOT_EQUAL(nullptr, (sTestItem*&)itemA);
+
+  Nonnull<sTestItem> itemA2 = astl::move(itemA);
+  CHECK_NOT_EQUAL(nullptr, (sTestItem*&)itemA2);
+  CHECK_EQUAL(nullptr, (sTestItem*&)itemA);
+
+  CHECK_EQUAL(1, itemA2->GetNumRefs());
+
+  CHECK_EQUAL(_ASTR("fooItem"), itemA2->_name);
+}
+
+TEST_FIXTURE(FNonnull,maybe) {
+  MaybePtr<sTestItem> itemA = ni::NewNonnull<sTestItem>("fooItem");
+  CHECK(itemA.has_value());
+  itemA.map([&](auto&& v) {
+    CHECK_EQUAL(1, v->GetNumRefs());
+    CHECK_EQUAL(_ASTR("fooItem"), v->_name);
+  });
+  CHECK_EQUAL(1, itemA.value()->GetNumRefs());
+}
+
+TEST_FIXTURE(FNonnull,maybe_ptr) {
+  {
+    MaybePtr<sTestItem> itemA = ni::NewMaybePtr<sTestItem>("fooItem");
+    CHECK(itemA.has_value());
+    CHECK_NOT_EQUAL(nullptr, (sTestItem*&)itemA.value());
+    itemA.map([&](auto&& v) {
+      CHECK_EQUAL(1, v->GetNumRefs());
+      CHECK_EQUAL(_ASTR("fooItem"), v->_name);
+    });
+  }
+
+  {
+    MaybePtr<sTestItem> itemA = ni::MakeMaybePtr((sTestItem*)NULL);
+    CHECK(!itemA.has_value());
+  }
+
+  {
+    MaybePtr<sTestItem> itemA;
+    CHECK(!itemA.has_value());
+  }
+}
+
+TEST_FIXTURE(FNonnull,value_or_fn) {
+  MaybePtr<sTestItem> itemA = ni::MakeMaybePtr((sTestItem*)NULL);
+  CHECK(!itemA.has_value());
+  Nonnull<sTestItem> r = itemA.value_or_fn([]() {
+    return ni::NewNonnull<sTestItem>("defaultItem");
+  });
+  CHECK_EQUAL(_ASTR("defaultItem"), r->_name);
+}
+
+TEST_FIXTURE(FNonnull,hash_set) {
+  Nonnull<sTestItem> itemA = ni::NewNonnull<sTestItem>("itemA");
+  Nonnull<sTestItem> itemB = ni::NewNonnull<sTestItem>("itemB");
+
+  astl::hash_set<ni::Nonnull<sTestItem> > hashedSet;
+  hashedSet.insert(itemA);
+  hashedSet.insert(itemB);
+  CHECK(astl::contains(hashedSet, itemA));
+  CHECK(astl::contains(hashedSet, itemB));
+}

--- a/sources/niLang/tsrc/Test_OSWindow.cpp
+++ b/sources/niLang/tsrc/Test_OSWindow.cpp
@@ -7,6 +7,8 @@
 
 using namespace ni;
 
+namespace {
+
 struct FOSWindow {
 };
 
@@ -332,4 +334,5 @@ TEST_FIXTURE(FOSWindow,PickDirectoryDialog) {
   }
 }
 
+} // end of anonymous namespace
 #endif

--- a/sources/niLang/tsrc/Test_STL_list.cpp
+++ b/sources/niLang/tsrc/Test_STL_list.cpp
@@ -4,6 +4,7 @@
 #include "../src/API/niLang/STL/vector.h"
 #include "../src/API/niLang/STL/map.h"
 
+namespace {
 // template class astl::list<ni::tInt>;
 
 typedef astl::list<ni::tInt> tIntLst;
@@ -85,3 +86,5 @@ TEST_FIXTURE(ASTL_list,U32Lst_pushback) {
   CHECK_EQUAL(3,vec.back());
   CHECK_EQUAL(3,vec.size());
 }
+
+} // end of anonymous namespace

--- a/sources/niLang/tsrc/Test_STL_map.cpp
+++ b/sources/niLang/tsrc/Test_STL_map.cpp
@@ -340,6 +340,7 @@ struct HashTable {
 //  Tests
 //
 //--------------------------------------------------------------------------------------------
+namespace {
 
 const ni::tU32 kNumTests = 100;
 
@@ -469,3 +470,5 @@ TEST_FIXTURE(ASTL_map,get_default) {
     CHECK_EQUAL(ni::eInvalidHandle,astl::get_default(hmap,"weee",ni::eInvalidHandle));
   }
 }
+
+} // end of anonymous namespace

--- a/sources/niLang/tsrc/Test_STL_memory.cpp
+++ b/sources/niLang/tsrc/Test_STL_memory.cpp
@@ -1,5 +1,8 @@
 #include "stdafx.h"
 #include "../src/API/niLang/STL/memory.h"
+
+namespace {
+
 using namespace ni;
 
 struct ASTL_memory {
@@ -73,3 +76,5 @@ TEST_FIXTURE(ASTL_memory, unique_ptr) {
 
   CHECK_EQUAL(false, (!!a));
 }
+
+} // end of anonymous namespace

--- a/sources/niLang/tsrc/Test_String.cpp
+++ b/sources/niLang/tsrc/Test_String.cpp
@@ -8,6 +8,9 @@
 #include "../src/API/niLang/StringLibIt.h"
 #include "../src/API/niLang/Utils/StrBreakIt.h"
 #include "../src/API/niLang_ModuleDef.h"
+#ifndef niEmbedded // no STL in general on embedded devices
+#include <string>
+#endif
 
 #include "Test_String.h"
 
@@ -204,6 +207,8 @@ static ni::cString _GetUTFPropertyMethod(ni::tBool abSet) {
   utfSetWriteBuffer[3] = (ni::achar)ni::StrToUpper(utfSet[3]);
   return utfSet;
 }
+
+namespace {
 
 // 10 chars
 static const ni::achar  _kaszTestString[] = _A("abcddefghi");
@@ -761,7 +766,6 @@ TEST_FIXTURE(niCore_String,NI_Str_CatSpeed)
 ///////////////////////////////////////////////
 // Test the native implementation for reference
 #ifndef niEmbedded // no STL in general on embedded devices
-#include <string>
 TEST_FIXTURE(niCore_String,STD_Str_CatSpeed)
 {
   TEST_TIMEREPORT();
@@ -1251,3 +1255,5 @@ TEST_FIXTURE(niCore_String,IntPtrIsOtherType) {
   CHECK_EQUAL(_ASTR("-321"), r.Set((intptr_t)-321));
   CHECK_EQUAL(_ASTR("987"), r.Set((uintptr_t)987));
 }
+
+} // end of anonymous namespace

--- a/sources/niScript/src/ScriptAutomation.cpp
+++ b/sources/niScript/src/ScriptAutomation.cpp
@@ -405,7 +405,7 @@ const achar* iunknown_gettype(HSQUIRRELVM v, cString& astrOut, iUnknown* apI)
   else {
     astl::set<cString> setIIDs;
 
-    MemberPointer<tUUIDCVec> uuidLst = tUUIDCVec::Create();
+    Nonnull<tUUIDCVec> uuidLst{tUUIDCVec::Create()};
     apI->ListInterfaces(uuidLst,0);
     niLoop(i,uuidLst->size()) {
       const tUUID& IID = uuidLst->at(i);
@@ -1019,7 +1019,7 @@ void cScriptAutomation::InitIntfDelegateLst(
   niAssert(vm != NULL);
 
   tUUID iidBaseInterface = niGetInterfaceUUID(iUnknown);
-  MemberPointer<tUUIDCVec> uuidLst = tUUIDCVec::Create();
+  Nonnull<tUUIDCVec> uuidLst{tUUIDCVec::Create()};
   apObj->ListInterfaces(
       uuidLst,
 #ifdef GETIUNKNOWN_INDEX_VTABLE

--- a/sources/niScript/src/sqfuncstate.h
+++ b/sources/niScript/src/sqfuncstate.h
@@ -84,10 +84,10 @@ struct SQFuncState
   bool _optimization;
 
   // contains number of nested exception traps
-  MemberPointer<tI32CVec> _breaktargets;
-  MemberPointer<tI32CVec> _unresolvedbreaks;
-  MemberPointer<tI32CVec> _continuetargets;
-  MemberPointer<tI32CVec> _unresolvedcontinues;
+  Nonnull<tI32CVec> _breaktargets;
+  Nonnull<tI32CVec> _unresolvedbreaks;
+  Nonnull<tI32CVec> _continuetargets;
+  Nonnull<tI32CVec> _unresolvedcontinues;
 };
 
 #endif //_SQFUNCSTATE_H_

--- a/sources/niUI/src/Camera.cpp
+++ b/sources/niUI/src/Camera.cpp
@@ -95,7 +95,7 @@ class cCamera : public ni::cIUnknownImpl<ni::iCamera,ni::eIUnknownImplFlags_Defa
     this->mvMove = pSrc->mvMove;
     this->mnMoveMode = pSrc->mnMoveMode;
     this->mMoveType = pSrc->mMoveType;
-    this->mFrustum = pSrc->mFrustum->Clone();
+    this->mFrustum->Copy(pSrc->mFrustum);
     this->mmtxView = pSrc->mmtxView;
     this->mmtxProj = pSrc->mmtxProj;
     this->mnDirtyFlags = pSrc->mnDirtyFlags;
@@ -597,23 +597,23 @@ class cCamera : public ni::cIUnknownImpl<ni::iCamera,ni::eIUnknownImplFlags_Defa
   }
 
  private:
-  ni::eCameraProjectionType   mProjection;
-  ni::sRectf mViewport;
-  ni::tF32    mfAspect, mfFov;
-  ni::tF32    mfNearPlane;
-  ni::tF32    mfFarPlane;
-  ni::tF32    mfOrthoSize;
-  ni::sVec3f mvMove;
-  ni::tU8   mnMoveMode;
-  ni::eCameraMoveType mMoveType;
-  ni::tU32    mnDirtyFlags;
-  ni::MemberPointer<ni::iFrustum> mFrustum;
-  ni::sMatrixf  mmtxView;
-  ni::sMatrixf  mmtxProj;
-  ni::sVec3f mvPos;
-  ni::sVec3f mvTarget;
-  ni::sVec3f mvTargetUp;
-  ni::sVec3f mvRayStart;
+  ni::eCameraProjectionType mProjection;
+  ni::sRectf                mViewport;
+  ni::tF32                  mfAspect, mfFov;
+  ni::tF32                  mfNearPlane;
+  ni::tF32                  mfFarPlane;
+  ni::tF32                  mfOrthoSize;
+  ni::sVec3f                mvMove;
+  ni::tU8                   mnMoveMode;
+  ni::eCameraMoveType       mMoveType;
+  ni::tU32                  mnDirtyFlags;
+  ni::Nonnull<ni::iFrustum> mFrustum;
+  ni::sMatrixf              mmtxView;
+  ni::sMatrixf              mmtxProj;
+  ni::sVec3f                mvPos;
+  ni::sVec3f                mvTarget;
+  ni::sVec3f                mvTargetUp;
+  ni::sVec3f                mvRayStart;
 
   niEndClass(cCamera);
 };

--- a/sources/niUI/src/GDRV_DX9.cpp
+++ b/sources/niUI/src/GDRV_DX9.cpp
@@ -3853,7 +3853,7 @@ class cD3D9 : public cIUnknownImpl<iGraphicsDriver,eIUnknownImplFlags_Default,iD
   IDirect3DStateBlock9*       mpD3D9DefaultDeviceStates;
   IDirect3DStateBlock9*       mpD3D9DefaultPixelStates;
   IDirect3DStateBlock9*       mpD3D9DefaultVertexStates;
-  MemberPointer<tD3D9LostDeviceSinkLst> mlstLostDeviceSinks;
+  Nonnull<tD3D9LostDeviceSinkLst> mlstLostDeviceSinks;
   tBool                       mbBeganRendering;
   astl::vector<sD3D9Context*> mvContexts;
   Ptr<iGraphicsDrawOpCapture> mptrDOCapture;

--- a/sources/niUI/src/MaterialLibrary.cpp
+++ b/sources/niUI/src/MaterialLibrary.cpp
@@ -191,9 +191,9 @@ class cMaterialLibrary : public cIUnknownImpl<ni::iMaterialLibrary,eIUnknownImpl
 
   typedef astl::hstring_hash_map<sTexture>  tTextureMap;
 
-  MemberPointer<tMaterialLibrarySinkLst>  _sinkList;
-  Ptr<iGraphics>          _graphics;
-  tHStringPtr               mhspBasePath;
+  Nonnull<tMaterialLibrarySinkLst> _sinkList;
+  Ptr<iGraphics>                   _graphics;
+  tHStringPtr                      mhspBasePath;
 
  public:
   ///////////////////////////////////////////////

--- a/sources/niUI/src/VGPolygonTesselator.h
+++ b/sources/niUI/src/VGPolygonTesselator.h
@@ -37,13 +37,13 @@ class cVGPolygonTesselator : public cIUnknownImpl<iVGPolygonTesselator>
   const tVec2fCVec* __stdcall GetTesselatedVertices() const;
 
  public:
-  tU32    mnNumContour;
-  tBool   mbBegan;
-  tBool   mbEvenOdd;
+  tU32 mnNumContour;
+  tBool mbBegan;
+  tBool mbEvenOdd;
   //! list of polygon vertices; only point 0 of triangle is valid
-  astl::vector<sVec2f>    mvPolyVerts;
+  astl::vector<sVec2f> mvPolyVerts;
   //! list with new triangles
-  MemberPointer<tVec2fCVec> mvFinalVerts;
+  Nonnull<tVec2fCVec> mvFinalVerts;
 
  private:
 #ifdef USE_GPC

--- a/sources/niUI/src/Widget.h
+++ b/sources/niUI/src/Widget.h
@@ -281,7 +281,7 @@ class cWidget : public cIUnknownImpl<iWidget,ni::eIUnknownImplFlags_DontInherit1
   tHStringPtr mhspSkinClass;
 
   cUIContext* mpUICtx;
-  MemberPointer<tWidgetSinkLst> mlstSinks;
+  Nonnull<tWidgetSinkLst> mlstSinks;
   sRectf mClientRect;
   sRectf mRect;
   sRectf mrectRelative;
@@ -291,20 +291,20 @@ class cWidget : public cIUnknownImpl<iWidget,ni::eIUnknownImplFlags_DontInherit1
   cWidgetZMap mZMap;
   tU32 mnStyle;
   sColor4f mcolBackground;
-  tU32  mStatus;
-  tU16  mClick;
-  Ptr<iFont>  mptrFont;
-  eWidgetDockStyle  mDockStyle;
+  tU32 mStatus;
+  tU16 mClick;
+  Ptr<iFont> mptrFont;
+  eWidgetDockStyle mDockStyle;
   eWidgetZOrder mZOrder;
-  sVec2f   mvMinSize,mvMaxSize;
-  sRectf   mrectDockFillClient;
-  sRectf   mrectDockFillNonClient;
-  Ptr<iWidget>  mpwContextMenu;
-  sVec4f   mvMargin;
-  sVec4f   mvPadding;
-  tWidgetAutoLayoutFlags  mnAutoLayout;
-  tU32      mnInputSubmitFlags;
-  tHStringPtr   mhspHoverText;
+  sVec2f mvMinSize,mvMaxSize;
+  sRectf mrectDockFillClient;
+  sRectf mrectDockFillNonClient;
+  Ptr<iWidget> mpwContextMenu;
+  sVec4f mvMargin;
+  sVec4f mvPadding;
+  tWidgetAutoLayoutFlags mnAutoLayout;
+  tU32 mnInputSubmitFlags;
+  tHStringPtr mhspHoverText;
 
   struct sContextMenu {
     sRectf     mRect;

--- a/sources/niUI/src/WidgetToolbar.cpp
+++ b/sources/niUI/src/WidgetToolbar.cpp
@@ -832,7 +832,7 @@ class cWidgetToolbar : public ni::cWidgetSinkImpl<ni::iWidgetToolbar>
   tTopWidgetVec     mvTopWidgets;
 
   // skin
-  MemberPointer<sToolbarSkin> skin;
+  Nonnull<sToolbarSkin> skin;
   void _UpdateSkinFlags() {
     niFlagOnIf(skin->flags,SKIN_AUTOHIDE,
                mbAutoHide);


### PR DESCRIPTION
## Formal Notes
<!---
- NOTE: Release notes are PUBLIC and go into the project's release notes. Other notes are internal.
- NOTE: Do NOT mention private/internal info in public RN.
- Release note format: "RN: module-name: Adds support for FooFeature."
- No-release note format: "NoRN: module-name: Improves or fixes FooThing."
- Use RN or NoRN for all the entires.
-->

This PR fixes:
* RN: niLang: Add `ni::Nonnull` & `astl::non_null`.
* RN: niLang: Safer API for `ni::Ptr`, `ni::QPtr` & `ni::WeakPtr`. Can be made strict with `#define niNoUnsafePtr`.

## Description, Motivation and Context

The goal is to introduce a clear set of safe C++ types that we
can use in our new code. Eventually the older part of the
codebase should be modernised to use these safer alternatives.

- New generic pointer types: `astl::non_null`.

- iUnknown pointer types with a common safe API: `ni::Ptr`, `ni::QPtr` & `ni::WeakPtr`.
  - `is_null` / `has_value`: Check whether the pointer points to an object.
  - `non_null` / `c_non_null`: Return the Nonnull pointer to the object. (Panic if trying to retrieve a Null object)
  - `raw_ptr`: Return the underlying pointer directly without any check.
- The safe API can be enforced with with `#define niNoUnsafePtr` - this will remove the unsafe accessor from ni::Ptr/ni::QPtr.
- Removed ni::MemberPointer and replaced it by ni::Nonnull.

Pointer types relationship, the types in blue are the new ones introduced in this PR:

![Screenshot 2022-09-03 at 10 56 34 AM](https://user-images.githubusercontent.com/164860/188253248-4c4e3b97-a881-4204-b3be-9da1cdff6ad5.jpg)

## How Has This Been Tested?
<!---
- Please describe in detail how you tested your changes.
- Include *full* CLI commands
- Include details of your testing environment, and the tests you ran to
- see how your change affects other areas of the code, etc.
-->

Command line to run all the tests that I run locally:
```
ham Run_ci
```

<!---
## Checklist:
* What I did is actually needed (I have a link to an issue and/or a meeting note/wiki doc to prove it)
* I have assigned appropriate labels and projects.
* My code is stylish, commented, and in the right place.
* I have added tests to cover my changes.
* All new and existing tests passed.
* I have updated the documentation appropriately.
-->

## Types of changes
<!---
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that cause existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [ ] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)

<!---
- This template is stored in .github/PULL_REQUEST_TEMPLATE.md
-->
