### PR TITLE
niLang: Added ability for dt paths to target children by index using '#'

### DIFF
--- a/sources/niLang/src/DataTable.cpp
+++ b/sources/niLang/src/DataTable.cpp
@@ -1493,29 +1493,8 @@ tBool __stdcall cDataTable::_FindChildDataTable(iDataTable* apThis, iDataTable* 
 cString __stdcall cLang::GetAbsoluteDataTablePath(iDataTable* apDT, tU32 anPropIndex)
 {
   niCheck(niIsOK(apDT),AZEROSTR);
-
-  cString ret;
-  if (anPropIndex != eInvalidHandle) {
-    ret += _A("@");
-    ret += apDT->GetPropertyName(anPropIndex);
-    niCheck(ret != _A("@"),AZEROSTR);
-  }
-
-  if  (apDT->GetParent()) {
-    while (apDT->GetParent()) {
-      cString cur;
-      cur = _A("/");
-      cur += apDT->GetName();
-      cur += ret;
-      ret = cur;
-      apDT = apDT->GetParent();
-    }
-  }
-  else {
-    ret = cString(_A("/")) + ret;
-  }
-
-  return ret;
+  cDataTablePath path(nullptr);
+  return path.GetRootPathToDataTable(apDT, anPropIndex);
 }
 
 static tBool _GetPathProperty(iDataTable* apDT, const achar* aPath, Ptr<iDataTable>& resDT, tU32& resIndex, tBool abCreate) {

--- a/sources/niLang/src/DataTablePath.cpp
+++ b/sources/niLang/src/DataTablePath.cpp
@@ -5,6 +5,8 @@
 #include "API/niLang/Utils/StringTokenizerImpl.h"
 #include "API/niLang/ILang.h"
 #include "DataTablePath.h"
+#include "niLang/IStringTokenizer.h"
+#include "niLang/StringLib.h"
 
 using namespace ni;
 
@@ -12,11 +14,14 @@ using namespace ni;
 // cDataTablePathOp implementation.
 
 ///////////////////////////////////////////////
-cDataTablePathOp::cDataTablePathOp(eDataTablePathOp aPathOp, const achar* aaszValue)
+cDataTablePathOp::cDataTablePathOp(eDataTablePathOp aPathOp,
+                                   const achar *aaszValue,
+                                   const achar *aaszPredicate)
 {
   ZeroMembers();
   mOp = aPathOp;
   mstrValue = aaszValue;
+  mstrPredicate = aaszPredicate;
   mptrRegex = ni::CreateFilePatternRegex(aaszValue,NULL);
 }
 
@@ -57,21 +62,42 @@ const cString& __stdcall cDataTablePathOp::GetValue() const
   return mstrValue;
 }
 
+///////////////////////////////////////////////
+const cString& __stdcall cDataTablePathOp::GetPredicate() const
+{
+  return mstrPredicate;
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 struct cDataTablePathParserTokenizer : public cIUnknownImpl<iStringTokenizer>
 {
-  cDataTablePathParserTokenizer() : mbFirstChar(eTrue) {}
+  cDataTablePathParserTokenizer() {}
 
   eStringTokenizerCharType __stdcall GetCharType(tU32 c) {
     eStringTokenizerCharType tokType = eStringTokenizerCharType_Normal;
-    if (c == '/' || c == '\\') {
-      tokType = mbFirstChar?eStringTokenizerCharType_SplitterAndToken:eStringTokenizerCharType_Splitter;
+    // slurp [predicate]
+    if (mInPredicate > 0) {
+      if (c == '[') {
+        ++mInPredicate;
+      } else if (c == ']') {
+        --mInPredicate;
+        if (mInPredicate == 0) {
+          tokType = eStringTokenizerCharType_SplitterAndToken;
+        }
+      }
     }
-    else if (c == '@' || c == ',') {
-      tokType = eStringTokenizerCharType_SplitterAndToken;
+    // handle regular tokens
+    else {
+      if (c == '/' || c == '\\' ||  c == '@' || c == ',') {
+        tokType = eStringTokenizerCharType_SplitterAndToken;
+      }
+      // start [predicate]
+      else if (c == '[') {
+        tokType = eStringTokenizerCharType_SplitterAndToken;
+        mInPredicate = 1;
+      }
     }
-    mbFirstChar = eFalse;
     return tokType;
   }
 
@@ -79,9 +105,8 @@ struct cDataTablePathParserTokenizer : public cIUnknownImpl<iStringTokenizer>
   }
 
  private:
-  tBool mbFirstChar;
+  tInt mInPredicate = 0;
 };
-
 
 tBool __stdcall ParseDataTablePathOp(const achar* aaszPath, tDataTablePathOpPtrCLst& aLst)
 {
@@ -90,12 +115,14 @@ tBool __stdcall ParseDataTablePathOp(const achar* aaszPath, tDataTablePathOpPtrC
   path = path.Trim();
   cDataTablePathParserTokenizer tokDT;
   StringTokenize(path,vToks,&tokDT);
-  astl::vector<cString>::iterator it = vToks.begin();
+  astl::vector<cString>::const_iterator it = vToks.begin();
   while (it != vToks.end())
   {
     // Root expression
     if (*it == _A("/") || *it == _A("\\")) {
-      aLst.push_back(niNew cDataTablePathOp(eDataTablePathOp_Root,it->Chars()));
+      if (it == vToks.begin()) {
+        aLst.push_back(niNew cDataTablePathOp(eDataTablePathOp_Root,it->Chars()));
+      }
     }
     // Property
     else if (*it == _A("@")) {
@@ -122,7 +149,27 @@ tBool __stdcall ParseDataTablePathOp(const achar* aaszPath, tDataTablePathOpPtrC
     }
     // DataTable
     else {
-      aLst.push_back(niNew cDataTablePathOp(eDataTablePathOp_DataTable,it->Chars()));
+      const cString &name = *it;
+      auto itNext = it + 1;
+      auto isPredicate = *it == _A("[");
+      auto lookaheadIsPredicate = itNext != vToks.end() && *itNext == _A("[");
+      if (!isPredicate && !lookaheadIsPredicate) {
+        aLst.push_back(niNew cDataTablePathOp(eDataTablePathOp_DataTable, name.Chars()));
+      } else {
+        const achar *childName;
+        if (isPredicate) {
+          childName = AZEROSTR;
+          // currently at '['
+        } else /* if (lookaheadIsPredicate) */ {
+          childName = name.Chars();
+          // currently at datatable name, following with predicate
+          ++it; // Move to '['
+        }
+        ++it; // Move to predicate
+        const cString &pred = *it;
+        ++it; // Move to ']'
+        aLst.push_back(niNew cDataTablePathOp(eDataTablePathOp_Predicate, childName, pred.Chars()));
+      }
     }
     ++it;
   }
@@ -240,20 +287,52 @@ tBool __stdcall cDataTablePath::Evaluate(iDataTable* apDT)
             return eFalse;
           }
           pCur = pCur->GetChildFromIndex(nS);
-          ++it;
-          continue;
+          break;
+        }
+      case eDataTablePathOp_Predicate:
+        {
+          const cString &name = pOp->GetValue();
+          // TODO: Support complex predicates
+          const tU32 nS = pOp->GetPredicate().ULong();
+          if (name.empty()) {
+            if (nS >= pCur->GetNumChildren()) {
+#pragma niTodo("Better error report mech, for now it bloats the output, so its disabled.")
+              // niError(niFmt(_A("Can't find child at index '%s' (%d)."), pOp->GetValue(), nS));
+              return eFalse;
+            }
+            pCur = pCur->GetChildFromIndex(nS);
+          } else {
+            tU32 namedChildFound = 0;
+            tBool found = eFalse;
+            niLoop(i, pCur->GetNumChildren()) {
+              auto child = pCur->GetChildFromIndex(i);
+              if (name.Eq(child->GetName())) {
+                if (nS == namedChildFound) {
+                  pCur = child;
+                  found = eTrue;
+                  break;
+                }
+                ++namedChildFound;
+              }
+            }
+            if (!found) {
+#pragma niTodo("Better error report mech, for now it bloats the output, so its disabled.")
+              // niError(niFmt(_A("Can't find child '%s[%d]'."), pOp->GetValue(), nS));
+              return eFalse;
+            }
+          }
+          break;
         }
       case eDataTablePathOp_Property:
         {
           tU32 nP;
-          for (nP = 0; nP < pCur->GetNumProperties(); ++nP)
-          {
+          for (nP = 0; nP < pCur->GetNumProperties(); ++nP) {
             if (pOp->GetRegex()->DoesMatch(pCur->GetPropertyName(nP)))
               break;
           }
           if (nP == pCur->GetNumProperties()) {
 #pragma niTodo("Better error report mech, for now it bloats the output, so its disabled.")
-            //niError(niFmt(_A("Can't find script property '%s'."), pOp->GetRegex()->GetRegexString()));
+            // niError(niFmt(_A("Can't find script property '%s'."), pOp->GetRegex()->GetRegexString()));
             return eFalse;
           }
           mResultType = eDataTablePathResultType_Property;
@@ -321,20 +400,41 @@ cString __stdcall cDataTablePath::GetRootPathToDataTable(iDataTable* apDT, tU32 
     niCheck(ret != _A("@"),AZEROSTR);
   }
 
-  if  (apDT->GetParent()) {
-    while (apDT->GetParent()) {
-      cString cur;
-      cur = _A("/");
-      cur += apDT->GetName();
-      cur += ret;
-      ret = cur;
-      apDT = apDT->GetParent();
+  cString tmp;
+  while (apDT->GetParent()) {
+
+    // Compute our 'per-name index'
+    const achar* childName = apDT->GetName();
+    tU32 childIndex = 0;
+    niLoop(i, apDT->GetParent()->GetNumChildren()) {
+      auto child = apDT->GetParent()->GetChildFromIndex(i);
+      if (child == apDT) {
+        break;
+      }
+      if (StrEq(childName, child->GetName())) {
+        ++childIndex;
+      }
     }
-  }
-  else {
-    ret = cString(_A("/")) + ret;
+
+    // Compute whatever should precede the current ret
+    tmp << childName;
+    if (childIndex > 0) {
+      // If our child index is different from 0 we use the predicate
+      // to ensure we will target the right data table (and property).
+      tmp << "[" << childIndex << "]";
+    }
+    tmp << "/";
+    tmp << ret;
+
+    // Update ret and clear the tmp
+    ret = tmp;
+    tmp.clear();
+
+    // Next loop, if necessary
+    apDT = apDT->GetParent();
   }
 
+  ret = cString(_A("/")) + ret;
   return ret;
 }
 

--- a/sources/niLang/src/DataTablePath.h
+++ b/sources/niLang/src/DataTablePath.h
@@ -58,8 +58,10 @@ enum eDataTablePathOp
   eDataTablePathOp_DataTable = 3,
   //! Path operation, property.
   eDataTablePathOp_Property = 4,
+  //! Path operation, datatable with predicate.
+  eDataTablePathOp_Predicate = 5,
   //! \internal
-  eDataTablePathOp_Last = 5,
+  eDataTablePathOp_Last = 6,
   //! \internal
   eDataTablePathOp_ForceDWORD = 0xFFFFFFFF
 };
@@ -71,7 +73,9 @@ class cDataTablePathOp : public cIUnknownImpl<iUnknown>
 
  public:
   //! Constructor.
-  cDataTablePathOp(eDataTablePathOp aPathOp, const achar* aaszValue);
+  cDataTablePathOp(eDataTablePathOp aPathOp,
+                   const achar *aaszValue,
+                   const achar *aaszPred = AZEROSTR);
   //! Destructor.
   ~cDataTablePathOp();
 
@@ -87,10 +91,12 @@ class cDataTablePathOp : public cIUnknownImpl<iUnknown>
   //// iDataTablePathOp ///////////////////////////
 
   const cString& __stdcall GetValue() const;
+  const cString& __stdcall GetPredicate() const;
 
  public:
-  eDataTablePathOp  mOp;
-  cString             mstrValue;
+  eDataTablePathOp mOp;
+  cString mstrValue;
+  cString mstrPredicate;
   Ptr<iRegex> mptrRegex;
 
   niEndClass(cDataTablePathOp);


### PR DESCRIPTION
- Added '#' as new token to target children by their index
- Added GetChildIndexFromDataTable: useful since 2 child dt could share a same name
- Updated GetAbsoluteDataTablePath to directly use cDataTablePath::GetRootPathToDataTable instead of duplicating the code
- GetAbsoluteDataTablePath now returns a path using data table indices instead of names to safely target properties in case multiple children are sharing the same name... Although this might have undesired side-effects to existing codebase that depend on the name being visible... Should probably provide an alternate method or flag to enable this instead.
- Added test cases for datatable paths

<!---
- Provide a general summary of your changes in the Title above
- Include your name with main subject of your change.
- Example: "Pierre: module-name: Added amazing new feature."
-->

## Formal Notes
<!---
- NOTE: Release notes are PUBLIC and go into the project's release notes. Other notes are internal.
- NOTE: Do NOT mention private/internal info in public RN.
- Release note format: "RN: module-name: Adds support for FooFeature."
- No-release note format: "NoRN: module-name: Improves or fixes FooThing."
- Use RN or NoRN for all the entires.
-->

This PR fixes:
* RN:
* RN:
* RN:

## Description, Motivation and Context
<!---
- A more detailed description of what's going on.
- Why is this change required? What problem does it solve?
- Link to related issues/PRs: Fixes #0000 / WiP #0000 / Closes #0000
-->

* Link to issue: Fixes ?
* Link to reference doc: ?

## How Has This Been Tested?
<!---
- Please describe in detail how you tested your changes.
- Include *full* CLI commands
- Include details of your testing environment, and the tests you ran to
- see how your change affects other areas of the code, etc.
-->

Command line to run all the tests that I run locally:
```
ham Run_Test_niLang FIXTURE=FDTSerialize-Path
```

<!---
## Checklist:
* What I did is actually needed (I have a link to an issue and/or a meeting note/wiki doc to prove it)
* I have assigned appropriate labels and projects.
* My code is stylish, commented, and in the right place.
* I have added tests to cover my changes.
* All new and existing tests passed.
* I have updated the documentation appropriately.
-->

## Types of changes
<!---
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that cause existing functionality to change)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [x] Testing/Build (test coverage or the test/build subsystems themselves)
* [ ] Packaging (adds examples or modifies a release package)

<!---
- This template is stored in .github/PULL_REQUEST_TEMPLATE.md
-->
