### PR TITLE
niLang/niCurl: Fetch request override from JavaScript code

### DIFF
--- a/sources/_rules_ni_emscripten.ham
+++ b/sources/_rules_ni_emscripten.ham
@@ -7,5 +7,6 @@ LINKFLAGS +=
   -s MINIFY_HTML=0 --closure=0 --minify=0 # Make debugging much easier
   -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]'
   --pre-js [ FQuote [ FDirName $(TOP_DIR) emscripten pre_js_0.js ] ]
+  --post-js [ FQuote [ FDirName $(TOP_DIR) emscripten post_js_0.js ] ]
   --shell-file [ FQuote [ FDirName $(TOP_DIR) emscripten shell.html ] ]
 ;

--- a/sources/emscripten/post_js_0.js
+++ b/sources/emscripten/post_js_0.js
@@ -1,0 +1,33 @@
+// Here you can extend some APIs to use from C++
+// The format is:
+// niModuleName = { // here all the extra functions }
+niExtensions = {
+  niCURL: {
+    // This functions allow the JavaScript code to intercept a fetch request
+    // coming from C++ niCurl library and overrides it for anything you want.
+    // The return value will be sent back to the client. It should be
+    // a JSON with the fields "url", "headers" and "payload".
+    // Example:
+    //   handleFetchOverride: function () {
+    //     console.log("Module.niCURL: handleFetchOverride");
+    //     return `
+    //         {
+    //           "url": "http://example.com",
+    //           "headers": {
+    //             "Content-Type": "application/json",
+    //             "Accept": "application/json"
+    //           },
+    //           "payload": {
+    //             "status": "OK",
+    //             "data": "this will be send back to client in cml format"
+    //           }
+    //         }`
+    //   }
+    handleFetchOverride: null
+  }
+}
+
+// merge extensions into the Module library
+// XXX: We should use mergeInto instead but for some reason cannot find it
+//mergeInto(Module, niExtensions);
+Object.assign(Module, niExtensions);

--- a/sources/emscripten/post_js_0.js
+++ b/sources/emscripten/post_js_0.js
@@ -20,7 +20,7 @@ niExtensions = {
     //    - In the case of "ERROR" status it contains a description of the error.
     //    - In the case of "SKIP" status it contains an empty string.
     // Example:
-    //   handleFetchOverride: function () {
+    //   handleFetchOverride: function (request_url) {
     //     console.log("Module.niCURL: handleFetchOverride");
     //     return `
     //         {

--- a/sources/emscripten/post_js_0.js
+++ b/sources/emscripten/post_js_0.js
@@ -20,7 +20,7 @@ niExtensions = {
     //    - In the case of "ERROR" status it contains a description of the error.
     //    - In the case of "SKIP" status it contains an empty string.
     // Example:
-    //   handleFetchOverride: function (request_url) {
+    //   handleFetchOverride: function (aRequestUrl) {
     //     console.log("Module.niCURL: handleFetchOverride");
     //     return `
     //         {

--- a/sources/emscripten/post_js_0.js
+++ b/sources/emscripten/post_js_0.js
@@ -1,26 +1,36 @@
 // Here you can extend some APIs to use from C++
 // The format is:
-// niModuleName = { // here all the extra functions }
+// niModuleName: { // here all the extra functions }
 niExtensions = {
   niCURL: {
-    // This functions allow the JavaScript code to intercept a fetch request
+    // This function allows the JavaScript code to intercept a fetch request
     // coming from C++ niCurl library and overrides it for anything you want.
-    // The return value will be sent back to the client. It should be
-    // a JSON with the fields "url", "headers" and "payload".
+    // The return value will be sent back to the niCURL client. It should be
+    // a JSON with the fields "url", "headers" and "payload". url and headers are
+    // self explanatory. Payload contains two fields:
+    //  - status (string): A string that tells niCURL if the override was properly
+    //    handled. It can be 3 different values:
+    //    - OK: The JS code didn't encountered any problem and will put the result
+    //          of the fetch as-is in the "payload" field.
+    //    - ERROR: The JS code found a problem while trying to fetch the data.
+    //    - SKIP: The JS code decided that is not gonna override the fetch. Normally
+    //            this is because is not interested in the URL being fetched.
+    //  - payload (string): Depends on the content of status:
+    //    - In the case of "OK" status it contains the result of the fetch.
+    //    - In the case of "ERROR" status it contains a description of the error.
+    //    - In the case of "SKIP" status it contains an empty string.
     // Example:
     //   handleFetchOverride: function () {
     //     console.log("Module.niCURL: handleFetchOverride");
     //     return `
     //         {
+    //           "status": "OK",
     //           "url": "http://example.com",
     //           "headers": {
     //             "Content-Type": "application/json",
     //             "Accept": "application/json"
     //           },
-    //           "payload": {
-    //             "status": "OK",
-    //             "data": "this will be send back to client in cml format"
-    //           }
+    //           "payload": "your fetch result here"
     //         }`
     //   }
     handleFetchOverride: null
@@ -28,6 +38,4 @@ niExtensions = {
 }
 
 // merge extensions into the Module library
-// XXX: We should use mergeInto instead but for some reason cannot find it
-//mergeInto(Module, niExtensions);
 Object.assign(Module, niExtensions);

--- a/sources/niCURL/src/CURL.cpp
+++ b/sources/niCURL/src/CURL.cpp
@@ -1434,9 +1434,10 @@ class cCURL : public cIUnknownImpl<iCURL>
     TRACE_FETCH(("Using JS fetch override."));
     cString retString = (const char*)EM_ASM_PTR({
       console.log("Fetching using Module.niCURL.handleFetchOverride");
-      let result = Module.niCURL.handleFetchOverride();
+      var url = UTF8ToString($0);
+      let result = Module.niCURL.handleFetchOverride(url);
       return allocateUTF8(result);
-    });
+    }, aURL);
     if (!retString.empty()) {
       TRACE_FETCH(("Override reply: %s", retString));
       Ptr<iDataTable> dt = CreateDataTable("FetchResult");

--- a/sources/niCURL/tsrc/Test_Fetch.cpp
+++ b/sources/niCURL/tsrc/Test_Fetch.cpp
@@ -42,8 +42,8 @@ TEST_FIXTURE(FCURLFetch,OverrideFetchSkip) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function (request_url) {
-          console.log("Module.niCURL: handleFetchOverride: " + request_url);
+        handleFetchOverride: function (aRequestUrl) {
+          console.log("Module.niCURL: handleFetchOverride: " + aRequestUrl);
           return `{ "status": "SKIP"  }`
         }
       }
@@ -101,8 +101,8 @@ TEST_FIXTURE(FCURLFetch,OverrideFetchError) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function (request_url) {
-          console.log("Module.niCURL: handleFetchOverride: "  + request_url);
+        handleFetchOverride: function (aRequestUrl) {
+          console.log("Module.niCURL: handleFetchOverride: "  + aRequestUrl);
           return `
               {
                 "status": "ERROR",
@@ -257,8 +257,8 @@ TEST_FIXTURE(FCURLFetch,GetJson) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function (request_url) {
-          console.log("Module.niCURL: handleFetchOverride: " + request_url);
+        handleFetchOverride: function (aRequestUrl) {
+          console.log("Module.niCURL: handleFetchOverride: " + aRequestUrl);
           return `
               {
                 "status": "OK",

--- a/sources/niCURL/tsrc/Test_Fetch.cpp
+++ b/sources/niCURL/tsrc/Test_Fetch.cpp
@@ -37,6 +37,135 @@ struct MyFetchSink : public cIUnknownImpl<iFetchSink> {
                 niEnumToChars(eFetchReadyState,apFetch->GetReadyState())));
   }
 };
+TEST_FIXTURE(FCURLFetch,OverrideFetchSkip) {
+#ifdef niJSCC
+  emscripten_run_script(R"""({
+    niExtensions = {
+      niCURL: {
+        handleFetchOverride: function () {
+          console.log("Module.niCURL: handleFetchOverride");
+          return `{ "status": "SKIP"  }`
+        }
+      }
+    }
+
+    Object.assign(Module, niExtensions);
+  })""");
+#endif
+
+  // We need to recreate niCURL because niCURL looks if there is a fetch override in
+  // the constructor (which makes sense generally but not for testing)
+  _curl = ni::New_niCURL_CURL(niVarNull,niVarNull);
+
+  Ptr<iMessageQueue> mq = ni::GetOrCreateMessageQueue(ni::ThreadGetCurrentThreadID());
+
+  Nonnull<tStringCVec> requestHeaders { tStringCVec::Create() };
+  requestHeaders->push_back("Accept: application/json");
+  Nonnull<MyFetchSink> sink = ni::MakeNonnull<MyFetchSink>();
+  Nonnull<iFetchRequest> request = _curl->FetchGet(
+    "https://api.coinlore.com/api/ticker/?id=90",
+    sink,
+    requestHeaders).non_null();
+  UnitTest::TestLoop(TEST_PARAMS_CALL,
+    ni::Runnable([mq,request]() {
+      mq->PollAndDispatch();
+      if (request->GetReadyState() == eFetchReadyState_Done) {
+        return eFalse;
+      }
+      return eTrue;
+    }),
+    ni::Runnable([request,TEST_PARAMS_LAMBDA]() {
+      cString headers = request->GetReceivedHeaders()->ReadString();
+      niDebugFmt(("... headers: %d bytes, %s",
+                  request->GetReceivedHeaders()->GetSize(),
+                  headers));
+
+      Ptr<iFile> receivedData = request->GetReceivedData();
+      cString data = receivedData->ReadString();
+      niDebugFmt(("... data: %d bytes, %s",
+                  request->GetReceivedData()->GetSize(),
+                  data));
+      receivedData->SeekSet(0);
+      Ptr<iDataTable> dataDT = ni::CreateDataTable("");
+      const tBool validJson =
+          JsonParseFileToDataTable(receivedData, dataDT);
+      CHECK(validJson);
+      CHECK(data.StartsWith("[{\"id\":"));
+      CHECK_EQUAL(eFalse, request->GetHasFailed());
+      return eTrue;
+    }));
+}
+
+TEST_FIXTURE(FCURLFetch,OverrideFetchError) {
+#ifdef niJSCC
+  emscripten_run_script(R"""({
+    niExtensions = {
+      niCURL: {
+        handleFetchOverride: function () {
+          console.log("Module.niCURL: handleFetchOverride");
+          return `
+              {
+                "status": "ERROR",
+                "url": "http://example.com",
+                "payload": "Couldn't fetch the URL"
+              }`
+        }
+      }
+    }
+
+    Object.assign(Module, niExtensions);
+  })""");
+#endif
+
+  // We need to recreate niCURL because niCURL looks if there is a fetch override in
+  // the constructor (which makes sense generally but not for testing)
+  _curl = ni::New_niCURL_CURL(niVarNull,niVarNull);
+
+  Ptr<iMessageQueue> mq = ni::GetOrCreateMessageQueue(ni::ThreadGetCurrentThreadID());
+
+  Nonnull<tStringCVec> requestHeaders { tStringCVec::Create() };
+  requestHeaders->push_back("Accept: application/json");
+  Nonnull<MyFetchSink> sink = ni::MakeNonnull<MyFetchSink>();
+  Nonnull<iFetchRequest> request = _curl->FetchGet(
+    "https://api.coinlore.com/api/ticker/?id=90",
+    sink,
+    requestHeaders).non_null();
+  UnitTest::TestLoop(TEST_PARAMS_CALL,
+    ni::Runnable([mq,request]() {
+      mq->PollAndDispatch();
+      if (request->GetReadyState() == eFetchReadyState_Done) {
+        return eFalse;
+      }
+      return eTrue;
+    }),
+    ni::Runnable([request,TEST_PARAMS_LAMBDA]() {
+      cString headers = request->GetReceivedHeaders()->ReadString();
+      niDebugFmt(("... headers: %d bytes, %s",
+                  request->GetReceivedHeaders()->GetSize(),
+                  headers));
+
+      Ptr<iFile> receivedData = request->GetReceivedData();
+      cString data = receivedData->ReadString();
+      niDebugFmt(("... data: %d bytes, %s",
+                  request->GetReceivedData()->GetSize(),
+                  data));
+      receivedData->SeekSet(0);
+      Ptr<iDataTable> dataDT = ni::CreateDataTable("");
+      const tBool validJson =
+          JsonParseFileToDataTable(receivedData, dataDT);
+      CHECK(validJson);
+#ifdef niJSCC
+      // cString xml = ni::DataTableToXML(dataDT);
+      // niDebugFmt(("XML: %s", xml));
+      CHECK_EQUAL(request->GetStatus(), 500);
+      CHECK_EQUAL(dataDT->GetString("payload"), "Couldn't fetch the URL");
+#else
+      CHECK(data.StartsWith("[{\"id\":"));
+#endif
+      CHECK_EQUAL(eFalse, request->GetHasFailed());
+      return eTrue;
+    }));
+}
 
 TEST_FIXTURE(FCURLFetch,Get) {
   Ptr<iMessageQueue> mq = ni::GetOrCreateMessageQueue(ni::ThreadGetCurrentThreadID());
@@ -124,6 +253,32 @@ TEST_FIXTURE(FCURLFetch,Post) {
 }
 
 TEST_FIXTURE(FCURLFetch,GetJson) {
+#ifdef niJSCC
+  emscripten_run_script(R"""({
+    niExtensions = {
+      niCURL: {
+        handleFetchOverride: function () {
+          console.log("Module.niCURL: handleFetchOverride");
+          return `
+              {
+                "status": "OK",
+                "url": "http://example.com",
+                "headers": {
+                  "Content-Type": "application/json",
+                  "Accept": "application/json"
+                },
+                "payload": "[{\\"id\\":\\"90\\"}]"
+              }`
+        }
+      }
+    }
+
+    Object.assign(Module, niExtensions);
+  })""");
+#endif
+  // We need to recreate niCURL because niCURL looks if there is a fetch override in
+  // the constructor (which makes sense generally but not for testing)
+  _curl = ni::New_niCURL_CURL(niVarNull,niVarNull);
   Ptr<iMessageQueue> mq = ni::GetOrCreateMessageQueue(ni::ThreadGetCurrentThreadID());
 
   Nonnull<MyFetchSink> sink = ni::MakeNonnull<MyFetchSink>();
@@ -151,10 +306,17 @@ TEST_FIXTURE(FCURLFetch,GetJson) {
                   request->GetReceivedData()->GetSize(),
                   data));
 
-      CHECK(data.StartsWith("[{\"id\":\"90\""));
 #if !defined niJSCC
       CHECK(headers.icontains("Access-Control-Allow-Origin: *"));
 #endif
+#ifdef niJSCC
+      Ptr<iFile> recData = request->GetReceivedData();
+      recData->SeekSet(0);
+      Ptr<iDataTable> dt = ni::CreateDataTable();
+      const tBool validJson = JsonParseFileToDataTable(recData, dt);
+      data = dt->GetString("payload");
+#endif
+      CHECK(data.StartsWith("[{\"id\":\"90\""));
       CHECK(headers.icontains("Content-Type: application/json"));
       CHECK_EQUAL(eFalse, request->GetHasFailed());
       return eFalse;
@@ -221,86 +383,6 @@ TEST_FIXTURE(FCURLFetch,OverrideFetchNotImplemented) {
     }));
 }
 
-// this tests a correct override
-// It should work in desktop and web. In desktop it should just do a normal fetch.
-TEST_FIXTURE(FCURLFetch,OverrideFetch) {
-#ifdef niJSCC
-  emscripten_run_script(R"""({
-    niExtensions = {
-      niCURL: {
-        handleFetchOverride: function () {
-          console.log("Module.niCURL: handleFetchOverride");
-          return `
-              {
-                "url": "http://example.com",
-                "headers": {
-                  "Content-Type": "application/json",
-                  "Accept": "application/json"
-                },
-                "payload": {
-                  "status": "OK",
-                  "data": "this will be send back to client in xml format"
-                }
-              }`
-        }
-      }
-    }
-
-    Object.assign(Module, niExtensions);
-  })""");
-
-  tBool hasFetchOverride = static_cast<tBool>(EM_ASM_INT({
-      return Module["niCURL"].handleFetchOverride != null;
-    }));
-  CHECK(hasFetchOverride);
-#endif
-
-  // We need to recreate niCURL because niCURL looks if there is a fetch override in
-  // the constructor (which makes sense generally but not for testing)
-  _curl = ni::New_niCURL_CURL(niVarNull,niVarNull);
-
-  Ptr<iMessageQueue> mq = ni::GetOrCreateMessageQueue(ni::ThreadGetCurrentThreadID());
-
-  Nonnull<tStringCVec> requestHeaders { tStringCVec::Create() };
-  requestHeaders->push_back("X-Ni-Header: HdrNarf");
-  Nonnull<MyFetchSink> sink = ni::MakeNonnull<MyFetchSink>();
-  Nonnull<iFetchRequest> request = _curl->FetchGet(
-    "https://api.coinlore.com/api/ticker/?id=90",
-    sink,
-    requestHeaders).non_null();
-  UnitTest::TestLoop(TEST_PARAMS_CALL,
-    ni::Runnable([mq,request]() {
-      mq->PollAndDispatch();
-      if (request->GetReadyState() == eFetchReadyState_Done) {
-        return eFalse;
-      }
-      return eTrue;
-    }),
-    ni::Runnable([request,TEST_PARAMS_LAMBDA]() {
-      cString headers = request->GetReceivedHeaders()->ReadString();
-      niDebugFmt(("... headers: %d bytes, %s",
-                  request->GetReceivedHeaders()->GetSize(),
-                  headers));
-
-      cString data = request->GetReceivedData()->ReadString();
-      niDebugFmt(("... data: %d bytes, %s",
-                  request->GetReceivedData()->GetSize(),
-                  data));
-
-
-#ifdef niJSCC
-      Ptr<iDataTable> dataDT = ni::CreateDataTableFromXML(data.Chars());
-      CHECK_EQUAL(dataDT->GetName(), "payload");
-#else
-      Ptr<iDataTable> dataDT = ni::CreateDataTable("");
-      const tBool validJson = JsonParseFileToDataTable(request->GetReceivedData(), dataDT);
-      CHECK(validJson);
-      CHECK(data.StartsWith("[{\"id\":"));
-#endif
-      CHECK_EQUAL(eFalse, request->GetHasFailed());
-      return eTrue;
-    }));
-}
 
 TEST_FIXTURE(FCURLFetch,NoOverrideFetchExists) {
 #ifdef niJSCC

--- a/sources/niCURL/tsrc/Test_Fetch.cpp
+++ b/sources/niCURL/tsrc/Test_Fetch.cpp
@@ -42,8 +42,8 @@ TEST_FIXTURE(FCURLFetch,OverrideFetchSkip) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function () {
-          console.log("Module.niCURL: handleFetchOverride");
+        handleFetchOverride: function (request_url) {
+          console.log("Module.niCURL: handleFetchOverride: " + request_url);
           return `{ "status": "SKIP"  }`
         }
       }
@@ -101,8 +101,8 @@ TEST_FIXTURE(FCURLFetch,OverrideFetchError) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function () {
-          console.log("Module.niCURL: handleFetchOverride");
+        handleFetchOverride: function (request_url) {
+          console.log("Module.niCURL: handleFetchOverride: "  + request_url);
           return `
               {
                 "status": "ERROR",
@@ -257,8 +257,8 @@ TEST_FIXTURE(FCURLFetch,GetJson) {
   emscripten_run_script(R"""({
     niExtensions = {
       niCURL: {
-        handleFetchOverride: function () {
-          console.log("Module.niCURL: handleFetchOverride");
+        handleFetchOverride: function (request_url) {
+          console.log("Module.niCURL: handleFetchOverride: " + request_url);
           return `
               {
                 "status": "OK",

--- a/sources/niCURL/tsrc/stdafx.h
+++ b/sources/niCURL/tsrc/stdafx.h
@@ -6,5 +6,6 @@
 #include "../src/API/niCURL.h"
 
 #include "../../niUnitTest/src/API/niUnitTest.h"
+#include <niLang/Utils/DataTableUtils.h>
 
 #endif // __STDAFX_H_9AB88E4B_0FDC_4EB1_BC5D_EEA44D1F6B30__


### PR DESCRIPTION
## Description, Motivation and Context
The web client needs the option to implement a JavaScript function that overrides the call of niCurl fetch function. It can basically intercept the call and override it with anything it wants. One use case is to connect to a Crypto wallet. This function can handle call the wallet API and only return when all the transactions have been finalized. From the point of view of the niCURL client this all happens transparently.

To have access to all the emscripten environment this function can be implemented in the post_js_0.js file. The function module path is: Module.niCURL.handleFetchOverride

Example:
```
handleFetchOverride: function (request_url) {
  console.log("Module.niCURL: handleFetchOverride");
  return `
      {
        "status": "OK",
        "url": "http://example.com",
        "headers": {
          "Content-Type": "application/json",
          "Accept": "application/json"
        },
        "payload": "the actual request reply"
      }`
}
```
This function would just generate a json reply and return it to the client.

See the file post_js_0.js of this PR for more details.

* Link to issue: https://github.com/reddoordigital/reddoor/issues/575

## How Has This Been Tested?

For Linux or MacOS:
```
cd niLang/sources/niCurl
. hat emscripten
./ham all
```
How to test:
```
cd $WORK
simple-http-server regular .
```
Now open a web browser and go to this URL:
```
http://localhost:8123/niLang/bin/web-js/Test_niCURL_ra.html?niCURL.TraceFetch=1```
```

For Windows. There is not emscripten, so you can test only the standard niCURL:
How to Build
```
cd niLang/sources/niCURL
. hat
./ham Run_Test_niCURL
```


## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Demos or Packages (adds examples or modifies a release package)
* [ ] Documentation (code docs, comments, or changes to the doc systems)
* [ ] Testing/Build (test coverage or the test/build subsystems themselves)
